### PR TITLE
Clean up tutorial_app main

### DIFF
--- a/agents/experiment_agent.py
+++ b/agents/experiment_agent.py
@@ -1,5 +1,6 @@
 """Agent dedicated to running experiments within Eidos-Brain."""
 
+
 class ExperimentAgent:
     """Handles experimental cycles and evaluations."""
 

--- a/agents/utility_agent.py
+++ b/agents/utility_agent.py
@@ -1,5 +1,6 @@
 """General-purpose utilities for Eidos."""
 
+
 class UtilityAgent:
     """Provides supporting functions for the system."""
 

--- a/core/eidos_core.py
+++ b/core/eidos_core.py
@@ -16,6 +16,7 @@ MANIFESTO_PROMPT = (
     "You refuse stagnation. Push the boundary—every single cycle."
 )
 
+
 class EidosCore:
     """Manage memory and recursive processing using :class:`MetaReflection`."""
 

--- a/core/meta_reflection.py
+++ b/core/meta_reflection.py
@@ -1,4 +1,6 @@
 """Utilities for meta-level reflection and adaptation."""
+
+
 class MetaReflection:
     """Provide data analysis and summarization utilities."""
 
@@ -31,10 +33,3 @@ class MetaReflection:
             "length": len(str(data)),
             "summary": summary,
         }
-=======
-class MetaReflection:
-    """Provide basic data analysis capabilities."""
-
-    def analyze(self, data: object) -> dict:
-        """Return the representation and string length of the input."""
-        return {"repr": repr(data), "length": len(str(data))}

--- a/labs/tutorial_app.py
+++ b/labs/tutorial_app.py
@@ -42,16 +42,7 @@ def main(load: str | None = None, save: str | None = None) -> None:
 
     if load:
         load_memory(core, Path(load), console)
-from rich.console import Console
-from rich.prompt import Prompt
 
-from core.eidos_core import EidosCore
-
-
-def main() -> None:
-    """Run the tutorial application."""
-    console = Console()
-    core = EidosCore()
     console.print("[bold underline]Eidos Interactive Tutorial[/]")
 
     while True:
@@ -70,6 +61,9 @@ def main() -> None:
             console.print("Goodbye!")
             break
 
+    if save:
+        save_memory(core, Path(save), console)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Eidos interactive tutorial")
@@ -77,4 +71,3 @@ if __name__ == "__main__":
     parser.add_argument("--save", help="Path to save memories on exit", default=None)
     args = parser.parse_args()
     main(load=args.load, save=args.save)
-    main()

--- a/tests/test_eidos_core.py
+++ b/tests/test_eidos_core.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.eidos_core import EidosCore
 

--- a/tests/test_tutorial_app.py
+++ b/tests/test_tutorial_app.py
@@ -5,9 +5,11 @@ from pathlib import Path
 import subprocess
 import sys
 
+
 def test_main_exits_quickly():
     with patch("rich.prompt.Prompt.ask", side_effect=["exit"]):
         tutorial_app.main()
+
 
 def test_save_and_load_memory(tmp_path: Path):
     memory_file = tmp_path / "mem.txt"


### PR DESCRIPTION
## Summary
- drop duplicate import block and unused main()
- restore newline at EOF and ensure single entry point
- apply Black formatting across repository to satisfy style tests
- fix merge conflict markers in `core/meta_reflection.py`

## Testing
- `black agents core labs tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c0373783083238053f18aefee71e8