### PR TITLE
Remove duplicate sys.path insert

### DIFF
--- a/tests/test_eidos_core.py
+++ b/tests/test_eidos_core.py
@@ -3,8 +3,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from core.eidos_core import EidosCore
 
 


### PR DESCRIPTION
## Summary
- deduplicate path adjustment in `tests/test_eidos_core.py`
- format with Black

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: missing dependency `rich` and syntax error in `core/meta_reflection.py`)*

------
https://chatgpt.com/codex/tasks/task_b_684c0378ac0c8323a242248670a5ae76