### PR TITLE
Add timestamped logging utilities

### DIFF
--- a/agents/utility_agent.py
+++ b/agents/utility_agent.py
@@ -1,5 +1,10 @@
 """General-purpose utilities for Eidos."""
 
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
 
 class UtilityAgent:
     """Provides supporting functions for the system."""
@@ -7,3 +12,29 @@ class UtilityAgent:
     def perform_task(self, task: str) -> str:
         """Perform a simple utility task and return a status message."""
         return f"Performed {task}"
+
+    def current_timestamp(self) -> str:
+        """Return the current UTC timestamp in ISO-8601 format."""
+        return datetime.utcnow().isoformat()
+
+    def log_with_timestamp(self, message: str, file_path: str | None = None) -> str:
+        """Return ``message`` prefixed with a timestamp and optionally log it.
+
+        Parameters
+        ----------
+        message:
+            Text to record in the log.
+        file_path:
+            Optional path to a file where the log line should be appended.
+
+        Returns
+        -------
+        str
+            The full timestamped log line.
+        """
+        line = f"[{self.current_timestamp()}] {message}"
+        if file_path:
+            path = Path(file_path)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        return line

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -10,6 +10,7 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 ## Agents
 - [ ] Explore new utility agents.
 - [ ] Expand agent features and tests.
+- [x] Implement timestamped logging utility.
 
 ## Tools
 - [ ] Build interactive CLI utilities for rapid experimentation.

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -65,3 +65,9 @@
 - Added `ROOT` constant to glossary via generation script
 
 **Next Target:** Explore deeper reflection summaries and expand CLI utilities
+
+## Cycle 9: Timestamped Logging
+- Added timestamped logging utilities in UtilityAgent
+- Updated templates with logging example
+
+**Next Target:** Improve automated logbook updates

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -11,6 +11,18 @@
 - main
 - save_memory
 
+## Methods
+- EidosCore.__init__
+- EidosCore.process_cycle
+- EidosCore.recurse
+- EidosCore.reflect
+- EidosCore.remember
+- ExperimentAgent.run
+- MetaReflection.analyze
+- UtilityAgent.current_timestamp
+- UtilityAgent.log_with_timestamp
+- UtilityAgent.perform_task
+
 ## Constants
 - MANIFESTO_PROMPT
 - ROOT

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -31,3 +31,12 @@ def main() -> None:
 if __name__ == "__main__":
     main()
 ```
+
+## Logging Template
+```python
+from datetime import datetime
+
+def timestamped_log(message: str) -> str:
+    """Return ``message`` prefixed with an ISO-8601 timestamp."""
+    return f"[{datetime.utcnow().isoformat()}] {message}"
+```

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -13,6 +13,16 @@ def test_utility_agent_perform_task():
     assert result == "Performed clean"
 
 
+def test_log_with_timestamp(tmp_path):
+    agent = UtilityAgent()
+    log_file = tmp_path / "log.txt"
+    line = agent.log_with_timestamp("hello", file_path=str(log_file))
+    assert line.endswith("hello")
+    content = log_file.read_text().strip()
+    assert content.endswith("hello")
+    assert line == content
+
+
 def test_experiment_agent_run():
     agent = ExperimentAgent()
     result = agent.run("hypothesis")

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -16,6 +16,9 @@ def extract_symbols(path: Path) -> list[tuple[str, str]]:
     for node in tree.body:
         if isinstance(node, ast.ClassDef):
             symbols.append((node.name, "class"))
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef):
+                    symbols.append((f"{node.name}.{item.name}", "method"))
         elif isinstance(node, ast.FunctionDef):
             symbols.append((node.name, "function"))
         elif isinstance(node, ast.Assign):
@@ -27,7 +30,12 @@ def extract_symbols(path: Path) -> list[tuple[str, str]]:
 
 def scan_codebase() -> dict[str, list[str]]:
     """Scan source directories for symbols grouped by kind."""
-    glossary: dict[str, list[str]] = {"class": [], "function": [], "constant": []}
+    glossary: dict[str, list[str]] = {
+        "class": [],
+        "function": [],
+        "method": [],
+        "constant": [],
+    }
     for directory in SOURCE_DIRS:
         for path in Path(directory).glob("*.py"):
             for name, kind in extract_symbols(path):
@@ -37,7 +45,12 @@ def scan_codebase() -> dict[str, list[str]]:
 
 def write_glossary(glossary: dict[str, list[str]]) -> None:
     """Write collected symbols to the glossary file."""
-    plural_map = {"class": "Classes", "function": "Functions", "constant": "Constants"}
+    plural_map = {
+        "class": "Classes",
+        "function": "Functions",
+        "method": "Methods",
+        "constant": "Constants",
+    }
     lines = ["# Glossary Reference", ""]
     for kind, names in glossary.items():
         header = plural_map.get(kind, kind.title() + "s")


### PR DESCRIPTION
## Summary
- implement `current_timestamp` and `log_with_timestamp` in `UtilityAgent`
- add logging template example
- extend tests for new logging feature
- include new methods in glossary
- document work in logbook and TODO
- update glossary generation script to capture methods

## Testing
- `black core agents labs tools tests --check`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c27e581b48323ae16bfa4faabe398