### PR TITLE
Add memory persistence to EidosCore

### DIFF
--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -65,3 +65,11 @@
 - Added `ROOT` constant to glossary via generation script
 
 **Next Target:** Explore deeper reflection summaries and expand CLI utilities
+
+## Cycle 9: Persistence in Core
+- Implemented `load_memory` and `save_memory` in `EidosCore`.
+- Integrated persistence with `process_cycle` via optional path argument.
+- Added tests covering new methods and cycle persistence.
+- Documented persistence pattern and updated templates.
+
+**Next Target:** Refine memory serialization for complex data types.

--- a/knowledge/recursive_patterns.md
+++ b/knowledge/recursive_patterns.md
@@ -9,3 +9,8 @@
 ### Combined Cycle Pattern
 Use `process_cycle` to store an experience and immediately recurse,
 appending reflective insights in a single step.
+
+### Memory Persistence Pattern
+Leverage `load_memory` and `save_memory` to maintain state across runs:
+1. Call `load_memory` with a file path before processing.
+2. Run `process_cycle` with the same path to automatically save results.

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -31,3 +31,16 @@ def main() -> None:
 if __name__ == "__main__":
     main()
 ```
+
+## Persistence Template
+```python
+from pathlib import Path
+
+def save_data(data: list[str], path: Path) -> None:
+    """Write each item in ``data`` to ``path`` separated by newlines."""
+    path.write_text("\n".join(data))
+
+def load_data(path: Path) -> list[str]:
+    """Return newline-separated entries from ``path`` if it exists."""
+    return path.read_text().splitlines() if path.exists() else []
+```

--- a/labs/tutorial_app.py
+++ b/labs/tutorial_app.py
@@ -15,23 +15,23 @@ from core.eidos_core import EidosCore
 
 
 def load_memory(core: EidosCore, path: Path, console: Console) -> None:
-    """Load memories from ``path`` if it exists."""
+    """Load memories from ``path`` using :class:`EidosCore`."""
     try:
+        core.load_memory(path)
         if path.exists():
-            core.memory = path.read_text().splitlines()
             console.print(f"Loaded {len(core.memory)} memories from {path}.")
         else:
             console.print(f"[yellow]No memory file at {path}, starting fresh.")
-    except OSError as exc:
+    except IOError as exc:
         console.print(f"[red]Failed to load memory: {exc}")
 
 
 def save_memory(core: EidosCore, path: Path, console: Console) -> None:
-    """Persist memories to ``path``."""
+    """Persist memories to ``path`` using :class:`EidosCore`."""
     try:
-        path.write_text("\n".join(map(str, core.memory)))
+        core.save_memory(path)
         console.print(f"Memories saved to {path}.")
-    except OSError as exc:
+    except IOError as exc:
         console.print(f"[red]Failed to save memory: {exc}")
 
 

--- a/tests/test_eidos_core.py
+++ b/tests/test_eidos_core.py
@@ -28,3 +28,24 @@ def test_process_cycle_combines_steps():
     assert "data" in memories
     assert any(isinstance(m, dict) and m.get("repr") == "'data'" for m in memories)
     assert len(memories) == 2
+
+
+def test_save_and_load_memory_methods(tmp_path):
+    core = EidosCore()
+    core.remember("hello")
+    path = tmp_path / "mem.txt"
+    core.save_memory(path)
+
+    new_core = EidosCore()
+    new_core.load_memory(path)
+    assert new_core.reflect() == ["hello"]
+
+
+def test_process_cycle_with_persistence(tmp_path):
+    path = tmp_path / "cycle.txt"
+    core = EidosCore()
+    core.process_cycle("data", memory_path=path)
+    assert path.exists()
+    lines = path.read_text().splitlines()
+    assert "data" in lines
+    assert len(lines) == 2


### PR DESCRIPTION
## Summary
- persist memories via `load_memory` and `save_memory` methods
- link persistence to `process_cycle`
- update tutorial app to use new methods
- expand tests for persistence
- document persistence pattern and template
- log progress in the Eidos logbook

## Testing
- `black core labs tests knowledge --quiet`
- `flake8 core labs tests knowledge`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c281a165c8323b711fc6e79e2fdd0