### PR TITLE
Refactor tutorial CLI and memory persistence

### DIFF
--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -65,3 +65,12 @@
 - Added `ROOT` constant to glossary via generation script
 
 **Next Target:** Explore deeper reflection summaries and expand CLI utilities
+
+## Cycle 9: CLI Consistency
+- Refactored `tutorial_app.py` to remove duplicated save calls
+- Introduced `load_memory` and `save_memory` helpers in the command loop
+- Renamed CLI options to `--load-memory` and `--save-memory`
+- Documented new options in `labs/tutorial.md`
+- Updated tests to reflect CLI changes
+
+**Next Target:** Automate glossary updates when symbols change

--- a/labs/tutorial.md
+++ b/labs/tutorial.md
@@ -14,5 +14,16 @@ This guide walks you through the `tutorial_app.py` application, which demonstrat
    ```
 3. Use the prompts to add experiences, view memories, and trigger recursion cycles.
 
+### Memory Persistence
+
+You can load or save a memory file when launching the tutorial:
+
+```bash
+python labs/tutorial_app.py --load-memory mem.txt --save-memory mem.txt
+```
+
+This preserves experiences between sessions using the helper functions
+`load_memory` and `save_memory`.
+
 The tutorial shows how memories are reflected upon and expanded using `MetaReflection`.
 

--- a/labs/tutorial_app.py
+++ b/labs/tutorial_app.py
@@ -35,13 +35,15 @@ def save_memory(core: EidosCore, path: Path, console: Console) -> None:
         console.print(f"[red]Failed to save memory: {exc}")
 
 
-def main(load: str | None = None, save: str | None = None) -> None:
+def main(
+    load_memory_path: str | None = None, save_memory_path: str | None = None
+) -> None:
     """Run the tutorial application."""
     console = Console()
     core = EidosCore()
 
-    if load:
-        load_memory(core, Path(load), console)
+    if load_memory_path:
+        load_memory(core, Path(load_memory_path), console)
     console.print("[bold underline]Eidos Interactive Tutorial[/]")
     while True:
         console.print("\nChoose an action: [add, reflect, recurse, exit]")
@@ -56,20 +58,28 @@ def main(load: str | None = None, save: str | None = None) -> None:
             core.recurse()
             console.print("Reflection complete. Insights appended.")
         elif action == "exit":
-            if save:
-                save_memory(core, Path(save), console)
             console.print("Goodbye!")
-            if save:
-                save_memory(core, Path(save), console)
             break
-
-    if save:
-        save_memory(core, Path(save), console)
+    if save_memory_path:
+        save_memory(core, Path(save_memory_path), console)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Eidos interactive tutorial")
-    parser.add_argument("--load", help="Path to memory file to load", default=None)
-    parser.add_argument("--save", help="Path to save memories on exit", default=None)
+    parser.add_argument(
+        "--load-memory",
+        help="Path to memory file to load",
+        dest="load_memory_path",
+        default=None,
+    )
+    parser.add_argument(
+        "--save-memory",
+        help="Path to save memories on exit",
+        dest="save_memory_path",
+        default=None,
+    )
     args = parser.parse_args()
-    main(load=args.load, save=args.save)
+    main(
+        load_memory_path=args.load_memory_path,
+        save_memory_path=args.save_memory_path,
+    )

--- a/tests/test_tutorial_app.py
+++ b/tests/test_tutorial_app.py
@@ -15,14 +15,14 @@ def test_save_and_load_memory(tmp_path: Path):
     with patch("rich.prompt.Prompt.ask", side_effect=["add", "hello", "exit"]), patch(
         "rich.console.Console.print"
     ) as mock_print:
-        tutorial_app.main(save=str(memory_file))
+        tutorial_app.main(save_memory_path=str(memory_file))
         save_output = "".join(call.args[0] for call in mock_print.call_args_list)
     assert memory_file.exists()
     assert "Memories saved" in save_output
     with patch("rich.prompt.Prompt.ask", side_effect=["reflect", "exit"]), patch(
         "rich.console.Console.print"
     ) as mock_print:
-        tutorial_app.main(load=str(memory_file))
+        tutorial_app.main(load_memory_path=str(memory_file))
         prints = "".join(call.args[0] for call in mock_print.call_args_list)
     assert "Loaded 1 memories" in prints
 


### PR DESCRIPTION
## Summary
- streamline memory persistence in `tutorial_app.py`
- rename CLI parameters to `--load-memory`/`--save-memory`
- document memory options in `labs/tutorial.md`
- update tests and logbook

## Testing
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c281cebcc8323886c07f4b99e7053