### PR TITLE
Update tutorial docs and CLI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,9 @@ Within `labs/`, `tutorial_app.py` offers an interactive introduction to
 
 See `knowledge/README.md` for further guidance.
 
+## Command-Line Tools
+- `labs/tutorial_app.py` – interactive tutorial with `--load` and `--save` options.
+- `tools/generate_glossary.py` – rebuilds `knowledge/glossary_reference.md`.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -6,3 +6,4 @@ Documentation includes:
 - `recursive_patterns.md` for design patterns
 - `templates.md` for coding templates
 - `emergent_insights.md` for derived knowledge
+- `glossary_reference.md` for a generated symbol list (run `tools/generate_glossary.py`)

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -65,3 +65,10 @@
 - Added `ROOT` constant to glossary via generation script
 
 **Next Target:** Explore deeper reflection summaries and expand CLI utilities
+
+## Cycle 9: Tutorial Workflow
+- Documented memory persistence and help output in `labs/tutorial.md`
+- Added command-line tool overview to `README.md`
+- Expanded knowledge README with glossary instructions
+
+**Next Target:** Automate glossary generation and refine CLI docs

--- a/labs/tutorial.md
+++ b/labs/tutorial.md
@@ -16,3 +16,18 @@ This guide walks you through the `tutorial_app.py` application, which demonstrat
 
 The tutorial shows how memories are reflected upon and expanded using `MetaReflection`.
 
+## Saving and Loading Memories
+
+To persist tutorial state between runs, supply memory paths via the CLI:
+
+```bash
+python labs/tutorial_app.py --load mem.txt --save mem.txt
+```
+
+The `--load` option reads existing memories at startup and `--save` writes all
+memories on exit. View available options anytime with:
+
+```bash
+python labs/tutorial_app.py --help
+```
+


### PR DESCRIPTION
## Summary
- expand tutorial guide with save/load instructions
- document command-line tools in README
- mention glossary generation in knowledge base
- log new cycle in eidos logbook

## Testing
- `pytest -q`
- `pytest tests/test_style.py -q`


------
https://chatgpt.com/codex/tasks/task_b_684c281dd43c8323aebc5c0128c1b2d5