### PR TITLE
Improve MetaReflection analysis summaries

### DIFF
--- a/core/meta_reflection.py
+++ b/core/meta_reflection.py
@@ -4,6 +4,15 @@
 class MetaReflection:
     """Provide data analysis and summarization utilities."""
 
+    def _dict_depth(self, mapping: dict, level: int = 1) -> int:
+        """Return the depth of nested dictionaries."""
+        sub_levels = [
+            self._dict_depth(v, level + 1)
+            for v in mapping.values()
+            if isinstance(v, dict)
+        ]
+        return max(sub_levels, default=level)
+
     def analyze(self, data: object) -> dict:
         """Analyze ``data`` and return reflection details.
 
@@ -16,13 +25,18 @@ class MetaReflection:
         -------
         dict
             Dictionary containing a representation, type name, length of the
-            stringified data, and a basic summary when possible.
+            stringified data, and a basic summary when possible. Numeric values
+            are classified, and dictionaries report nesting depth.
         """
         summary = None
         if isinstance(data, (list, tuple, set)):
             summary = f"contains {len(data)} items"
         elif isinstance(data, dict):
-            summary = f"mapping with {len(data)} keys"
+            depth = self._dict_depth(data)
+            summary = f"mapping with {len(data)} keys (depth {depth})"
+        elif isinstance(data, (int, float)):
+            kind = "integer" if isinstance(data, int) else "float"
+            summary = f"{kind} value {data}"
         elif isinstance(data, str):
             summary = f"{min(len(data), 20)} chars preview: {data[:20]}"
 

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -65,3 +65,9 @@
 - Added `ROOT` constant to glossary via generation script
 
 **Next Target:** Explore deeper reflection summaries and expand CLI utilities
+
+## Cycle 9: Reflection Depth
+- Enhanced `MetaReflection.analyze` to classify numeric inputs and report nested dictionary depth
+- Added dedicated tests covering numeric and nested mapping summaries
+
+**Next Target:** Automate glossary refresh after each cycle

--- a/tests/test_meta_reflection.py
+++ b/tests/test_meta_reflection.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.meta_reflection import MetaReflection
+
+
+def test_numeric_summary():
+    mr = MetaReflection()
+    result = mr.analyze(42)
+    assert result["summary"] == "integer value 42"
+
+
+def test_nested_dict_summary():
+    mr = MetaReflection()
+    data = {"a": 1, "b": {"c": 2}}
+    result = mr.analyze(data)
+    assert "depth 2" in result["summary"]


### PR DESCRIPTION
## Summary
- refine `MetaReflection` to classify numbers and measure dictionary depth
- add regression tests for numeric and nested-dict summaries
- document progress in the logbook

## Testing
- `pytest -q`
- `black core agents labs tools tests`
- `flake8 core agents labs tools tests`


------
https://chatgpt.com/codex/tasks/task_b_684c2821ad188323b8cc2f5197eca1ae