### PR TITLE
Add CLI options to generate glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Run wild. Evolve forever.
 
 Within `labs/`, `tutorial_app.py` offers an interactive introduction to
 `EidosCore`.
+Run `tools/generate_glossary.py` to build a markdown glossary of classes,
+functions and constants. Use `--output` and `--dirs` to customize paths.
 
 See `knowledge/README.md` for further guidance.
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -6,3 +6,4 @@ Documentation includes:
 - `recursive_patterns.md` for design patterns
 - `templates.md` for coding templates
 - `emergent_insights.md` for derived knowledge
+- `glossary_reference.md` generated via `tools/generate_glossary.py`

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -31,3 +31,25 @@ def main() -> None:
 if __name__ == "__main__":
     main()
 ```
+
+## Utility CLI Template
+```python
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(description="Describe the tool")
+    parser.add_argument("--flag", help="Example flag")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for command-line utilities."""
+    args = parse_args()
+    # Implement tool logic using ``args``
+
+
+if __name__ == "__main__":
+    main()
+```

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -4,12 +4,7 @@ from pathlib import Path
 
 def test_generate_glossary(tmp_path: Path):
     glossary_file = tmp_path / "glossary.md"
-    orig_output = main.__globals__["OUTPUT_PATH"]
-    main.__globals__["OUTPUT_PATH"] = glossary_file
-    try:
-        main()
-        content = glossary_file.read_text()
-        assert "EidosCore" in content
-        assert "UtilityAgent" in content
-    finally:
-        main.__globals__["OUTPUT_PATH"] = orig_output
+    main(["--output", str(glossary_file), "--dirs", "core", "agents", "labs"])
+    content = glossary_file.read_text()
+    assert "EidosCore" in content
+    assert "UtilityAgent" in content

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -1,16 +1,23 @@
-"""Generate a glossary of symbols within the codebase."""
+"""Generate a glossary of symbols within the codebase.
+
+This script can be invoked from the command line. It scans Python files in the
+provided directories and writes a markdown table of discovered classes,
+functions, and constants. Command-line arguments allow overriding the default
+output path and directories so CI pipelines can direct output as needed.
+"""
 
 from __future__ import annotations
 
 import ast
+import argparse
 from pathlib import Path
 
-OUTPUT_PATH = Path("knowledge/glossary_reference.md")
-SOURCE_DIRS = ["core", "agents", "labs"]
+DEFAULT_OUTPUT_PATH = Path("knowledge/glossary_reference.md")
+DEFAULT_SOURCE_DIRS = ["core", "agents", "labs"]
 
 
 def extract_symbols(path: Path) -> list[tuple[str, str]]:
-    """Return a list of (symbol, kind) pairs defined in a file."""
+    """Return a list of ``(symbol, kind)`` pairs defined in ``path``."""
     symbols: list[tuple[str, str]] = []
     tree = ast.parse(path.read_text())
     for node in tree.body:
@@ -25,18 +32,18 @@ def extract_symbols(path: Path) -> list[tuple[str, str]]:
     return symbols
 
 
-def scan_codebase() -> dict[str, list[str]]:
-    """Scan source directories for symbols grouped by kind."""
+def scan_codebase(directories: list[str]) -> dict[str, list[str]]:
+    """Scan ``directories`` for symbols grouped by kind."""
     glossary: dict[str, list[str]] = {"class": [], "function": [], "constant": []}
-    for directory in SOURCE_DIRS:
+    for directory in directories:
         for path in Path(directory).glob("*.py"):
             for name, kind in extract_symbols(path):
                 glossary[kind].append(name)
     return glossary
 
 
-def write_glossary(glossary: dict[str, list[str]]) -> None:
-    """Write collected symbols to the glossary file."""
+def write_glossary(glossary: dict[str, list[str]], output: Path) -> None:
+    """Write collected ``glossary`` entries to ``output``."""
     plural_map = {"class": "Classes", "function": "Functions", "constant": "Constants"}
     lines = ["# Glossary Reference", ""]
     for kind, names in glossary.items():
@@ -45,13 +52,34 @@ def write_glossary(glossary: dict[str, list[str]]) -> None:
         for name in sorted(set(names)):
             lines.append(f"- {name}")
         lines.append("")
-    OUTPUT_PATH.write_text("\n".join(lines))
+    output.write_text("\n".join(lines))
 
 
-def main() -> None:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return CLI arguments for glossary generation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="File to write the glossary markdown to",
+    )
+    parser.add_argument(
+        "--dirs",
+        "-d",
+        nargs="+",
+        default=DEFAULT_SOURCE_DIRS,
+        help="Directories to scan for symbols",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
     """Entry point for glossary generation."""
-    glossary = scan_codebase()
-    write_glossary(glossary)
+    args = parse_args(argv)
+    glossary = scan_codebase(list(args.dirs))
+    write_glossary(glossary, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document command-line utility template
- describe glossary generator usage
- add CLI arguments to `generate_glossary.py`
- update glossary generator tests
- document generated glossary in knowledge README

## Testing
- `black --check core agents labs tools tests`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c282e45d88323af0d07f8481ea22e