### PR TITLE
Add persistence tests

### DIFF
--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -65,3 +65,10 @@
 - Added `ROOT` constant to glossary via generation script
 
 **Next Target:** Explore deeper reflection summaries and expand CLI utilities
+
+## Cycle 9: Persistence Validation
+- Added targeted tests for `load_memory` and `save_memory` functions
+- Confirmed recursion still operates after loading saved memories
+- Documented persistence checks in test suite
+
+**Next Target:** Improve reflection detail generation and automate glossary updates

--- a/tests/test_tutorial_app.py
+++ b/tests/test_tutorial_app.py
@@ -39,3 +39,37 @@ def test_cli_help():
     )
     assert result.returncode == 0
     assert "Eidos interactive tutorial" in result.stdout
+
+
+def test_save_memory_creates_file(tmp_path: Path) -> None:
+    """Ensure ``save_memory`` writes data to disk."""
+    core = tutorial_app.EidosCore()
+    core.remember("note")
+    file_path = tmp_path / "saved.txt"
+    console = tutorial_app.Console(record=True)
+    tutorial_app.save_memory(core, file_path, console)
+    assert file_path.exists()
+    assert file_path.read_text() == "note"
+    assert "Memories saved" in console.export_text()
+
+
+def test_load_memory_existing_file(tmp_path: Path) -> None:
+    """Verify ``load_memory`` populates core from an existing file."""
+    file_path = tmp_path / "loaded.txt"
+    file_path.write_text("a\nb\n")
+    core = tutorial_app.EidosCore()
+    console = tutorial_app.Console(record=True)
+    tutorial_app.load_memory(core, file_path, console)
+    assert core.memory == ["a", "b"]
+    assert "Loaded 2 memories" in console.export_text()
+
+
+def test_recursion_after_load(tmp_path: Path) -> None:
+    """Ensure recursion continues to work after loading memories."""
+    file_path = tmp_path / "recurse.txt"
+    file_path.write_text("hello")
+    core = tutorial_app.EidosCore()
+    tutorial_app.load_memory(core, file_path, tutorial_app.Console())
+    core.recurse()
+    assert len(core.memory) == 2
+    assert any(isinstance(m, dict) for m in core.memory)


### PR DESCRIPTION
## Summary
- add tests for `load_memory` and `save_memory`
- ensure recursion works after loading saved memories
- log new cycle in `eidos_logbook.md`

## Testing
- `pytest -q`
- `black --check --diff core agents labs tools tests`
- `flake8 core agents labs tools tests`

------
https://chatgpt.com/codex/tasks/task_b_684c28505b188323b66abaee61bc2ae4