### PR TITLE
Add async event bus

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .event_bus import EventBus
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "EventBus"]

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -1,0 +1,34 @@
+"""Async publish/subscribe event bus for agent communication."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Dict, List
+
+
+class EventBus:
+    """Asynchronous publish/subscribe event bus."""
+
+    def __init__(self) -> None:
+        """Initialize the bus with empty subscriber lists."""
+        self._subscribers: Dict[str, List[Callable[[Any], Awaitable[None]]]] = (
+            defaultdict(list)
+        )
+
+    async def subscribe(
+        self, event: str, handler: Callable[[Any], Awaitable[None]]
+    ) -> None:
+        """Register ``handler`` for ``event``."""
+        self._subscribers[event].append(handler)
+
+    async def unsubscribe(
+        self, event: str, handler: Callable[[Any], Awaitable[None]]
+    ) -> None:
+        """Remove ``handler`` from ``event`` subscriptions."""
+        if handler in self._subscribers.get(event, []):
+            self._subscribers[event].remove(handler)
+
+    async def publish(self, event: str, data: Any) -> None:
+        """Publish ``data`` to all subscribers of ``event``."""
+        await asyncio.gather(*(h(data) for h in list(self._subscribers.get(event, []))))

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,20 +1,18 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
-- EidosCore
-- ExperimentAgent
-- MetaReflection
-- UtilityAgent
+-EidosCore
+-EventBus
+-ExperimentAgent
+-MetaReflection
+-UtilityAgent
 
 ## Functions
-- load_memory
-- main
-- save_memory
+-build_parser
+-load_memory
+-main
+-save_memory
 
 ## Constants
-- MANIFESTO_PROMPT
-- ROOT
+-MANIFESTO_PROMPT
+-ROOT

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from core.event_bus import EventBus
+
+
+def test_publish_and_receive() -> None:
+    bus = EventBus()
+    received: list[int] = []
+
+    async def handler(data: int) -> None:
+        received.append(data)
+
+    async def run() -> None:
+        await bus.subscribe("num", handler)
+        await bus.publish("num", 5)
+        await asyncio.sleep(0)  # allow tasks to complete
+
+    asyncio.run(run())
+    assert received == [5]
+
+
+def test_unsubscribe() -> None:
+    bus = EventBus()
+    received: list[str] = []
+
+    async def handler(data: str) -> None:
+        received.append(data)
+
+    async def run() -> None:
+        await bus.subscribe("msg", handler)
+        await bus.unsubscribe("msg", handler)
+        await bus.publish("msg", "hi")
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+    assert received == []
+
+
+def test_multiple_subscribers() -> None:
+    bus = EventBus()
+    order: list[str] = []
+
+    async def a(data: str) -> None:
+        order.append("a")
+
+    async def b(data: str) -> None:
+        order.append("b")
+
+    async def run() -> None:
+        await bus.subscribe("note", a)
+        await bus.subscribe("note", b)
+        await bus.publish("note", "x")
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+    assert sorted(order) == ["a", "b"]


### PR DESCRIPTION
## Summary
- implement `EventBus` for async agent communication
- expose `EventBus` from `core`
- update glossary
- test event bus functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c05e7e083239e24c5fa39610b93