### PR TITLE
Add Agent interface and refactor ExperimentAgent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,6 +1,7 @@
 """Collection of autonomous agents for Eidos-Brain."""
 
+from .agent import Agent
 from .utility_agent import UtilityAgent
 from .experiment_agent import ExperimentAgent
 
-__all__ = ["UtilityAgent", "ExperimentAgent"]
+__all__ = ["Agent", "UtilityAgent", "ExperimentAgent"]

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,0 +1,14 @@
+"""Base interface for all Eidos agents."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Agent(ABC):
+    """Define the minimal interface required for Eidos agents."""
+
+    @abstractmethod
+    def run(self, *args, **kwargs) -> object:
+        """Execute the agent's primary behavior."""
+        raise NotImplementedError

--- a/agents/experiment_agent.py
+++ b/agents/experiment_agent.py
@@ -1,7 +1,11 @@
 """Agent dedicated to running experiments within Eidos-Brain."""
 
+from __future__ import annotations
 
-class ExperimentAgent:
+from .agent import Agent
+
+
+class ExperimentAgent(Agent):
     """Handles experimental cycles and evaluations."""
 
     def run(self, hypothesis: str) -> str:

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,14 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
+- Agent
 - EidosCore
 - ExperimentAgent
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from agents.agent import Agent
 from agents.utility_agent import UtilityAgent
 from agents.experiment_agent import ExperimentAgent
 
@@ -29,3 +30,8 @@ def test_experiment_agent_run_series():
     agent = ExperimentAgent()
     results = agent.run_series(["h1", "h2"])
     assert results == ["Experimenting with h1", "Experimenting with h2"]
+
+
+def test_experiment_agent_is_agent() -> None:
+    """``ExperimentAgent`` should adhere to the ``Agent`` interface."""
+    assert issubclass(ExperimentAgent, Agent)


### PR DESCRIPTION
## Summary
- create `Agent` abstract base class
- refactor `ExperimentAgent` to implement `Agent`
- export `Agent` via agents package
- update glossary with new symbol
- test inheritance relationship

## Testing
- `flake8`
- `black --check --diff core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c0956848323a8727d4f45e96106