### PR TITLE
Introduce Agent base class

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,6 +1,7 @@
 """Collection of autonomous agents for Eidos-Brain."""
 
+from .agent import Agent
 from .utility_agent import UtilityAgent
 from .experiment_agent import ExperimentAgent
 
-__all__ = ["UtilityAgent", "ExperimentAgent"]
+__all__ = ["Agent", "UtilityAgent", "ExperimentAgent"]

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,0 +1,19 @@
+"""Shared base interface for all Eidos agents."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class Agent(ABC):
+    """Base interface declaring common agent behavior."""
+
+    @abstractmethod
+    def perform_task(self, task: str) -> str:
+        """Perform a single ``task`` and return a status message."""
+        raise NotImplementedError
+
+    def batch_perform(self, tasks: List[str]) -> List[str]:
+        """Perform multiple tasks via :py:meth:`perform_task`."""
+        return [self.perform_task(t) for t in tasks]

--- a/agents/utility_agent.py
+++ b/agents/utility_agent.py
@@ -1,13 +1,11 @@
 """General-purpose utilities for Eidos."""
 
+from .agent import Agent
 
-class UtilityAgent:
+
+class UtilityAgent(Agent):
     """Provides supporting functions for the system."""
 
     def perform_task(self, task: str) -> str:
         """Perform a simple utility task and return a status message."""
         return f"Performed {task}"
-
-    def batch_perform(self, tasks: list[str]) -> list[str]:
-        """Perform multiple tasks and collect status messages."""
-        return [self.perform_task(t) for t in tasks]

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,11 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Agent Base Introduction
+- Created abstract :class:`Agent` base class for common behavior
+- Refactored :class:`UtilityAgent` to inherit from :class:`Agent`
+- Expanded agent tests to verify base class adherence
+- Updated package exports and glossary documentation
+
+**Next Target:** Integrate :class:`Agent` with additional utilities

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -6,6 +6,7 @@ Refer back to `templates.md` for code usage examples and to
 
 ## Classes
 - EidosCore
+- Agent
 - ExperimentAgent
 - MetaReflection
 - UtilityAgent

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from agents.agent import Agent
 from agents.utility_agent import UtilityAgent
 from agents.experiment_agent import ExperimentAgent
 
@@ -29,3 +30,8 @@ def test_experiment_agent_run_series():
     agent = ExperimentAgent()
     results = agent.run_series(["h1", "h2"])
     assert results == ["Experimenting with h1", "Experimenting with h2"]
+
+
+def test_utility_agent_is_subclass():
+    agent = UtilityAgent()
+    assert isinstance(agent, Agent)


### PR DESCRIPTION
## Summary
- create `Agent` base interface for shared agent behaviour
- refactor `UtilityAgent` to inherit from `Agent`
- export the new interface from the agents package
- verify inheritance in the agent test suite
- document the addition in the logbook and glossary

## Testing
- `black agents tests knowledge -q`
- `flake8 agents tests knowledge`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c0a49fc8323a2650078d627de1c