### PR TITLE
Implement dynamic agent loader and event bus

### DIFF
--- a/agents/experiment_agent.py
+++ b/agents/experiment_agent.py
@@ -1,8 +1,15 @@
 """Agent dedicated to running experiments within Eidos-Brain."""
 
+from core.event_bus import EventBus
+
 
 class ExperimentAgent:
     """Handles experimental cycles and evaluations."""
+
+    def register(self, bus: "EventBus") -> None:
+        """Attach experiment handlers to ``bus``."""
+        bus.subscribe("experiment_run", self.run)
+        bus.subscribe("experiment_series", self.run_series)
 
     def run(self, hypothesis: str) -> str:
         """Execute an experiment and return its result."""

--- a/agents/utility_agent.py
+++ b/agents/utility_agent.py
@@ -1,8 +1,14 @@
 """General-purpose utilities for Eidos."""
 
+from core.event_bus import EventBus
+
 
 class UtilityAgent:
     """Provides supporting functions for the system."""
+
+    def register(self, bus: "EventBus") -> None:
+        """Attach this agent's handlers to ``bus``."""
+        bus.subscribe("utility_task", self.perform_task)
 
     def perform_task(self, task: str) -> str:
         """Perform a simple utility task and return a status message."""

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,7 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .event_bus import EventBus
+from .agent_loader import load_agents
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "EventBus", "load_agents"]

--- a/core/agent_loader.py
+++ b/core/agent_loader.py
@@ -1,0 +1,26 @@
+"""Automatically load agents and attach them to the event bus."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any
+
+from agents import __path__ as AGENT_PATH
+
+from .event_bus import EventBus
+
+
+def load_agents(bus: EventBus) -> dict[str, Any]:
+    """Discover agent classes and register them with ``bus``."""
+    instances: dict[str, Any] = {}
+    for _, module_name, _ in pkgutil.iter_modules(AGENT_PATH):
+        module = importlib.import_module(f"agents.{module_name}")
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if name.endswith("Agent"):
+                instance = obj()
+                if hasattr(instance, "register"):
+                    instance.register(bus)
+                instances[name] = instance
+    return instances

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -1,0 +1,34 @@
+"""Simple event bus for agent communication."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable
+
+
+class EventBus:
+    """Central hub for pub/sub messaging."""
+
+    def __init__(self) -> None:
+        """Initialize empty subscriber registry."""
+        self._subscribers: dict[str, list[Callable[..., Any]]] = defaultdict(list)
+
+    def subscribe(self, event: str, handler: Callable[..., Any]) -> None:
+        """Register a ``handler`` for a named ``event``."""
+        self._subscribers[event].append(handler)
+
+    def publish(self, event: str, *args: Any, **kwargs: Any) -> list[Any]:
+        """Broadcast ``event`` to all handlers and collect responses."""
+        results = []
+        for func in self._subscribers.get(event, []):
+            results.append(func(*args, **kwargs))
+        return results
+
+    def clear(self) -> None:
+        """Remove all registered handlers."""
+        self._subscribers.clear()
+
+    @property
+    def subscribers(self) -> dict[str, list[Callable[..., Any]]]:
+        """Expose current subscriber mapping."""
+        return dict(self._subscribers)

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,8 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: 2025-06-13 13:50 UTC
+- Added event bus and agent loader
+
+**Next Target:** Expand event-driven experiments

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,15 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
+- EventBus
 - ExperimentAgent
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
+- load_agents
 - load_memory
 - main
 - save_memory

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core import EventBus, load_agents
+
+
+def test_load_agents_registers_handlers():
+    bus = EventBus()
+    agents = load_agents(bus)
+    assert "UtilityAgent" in agents
+    assert "ExperimentAgent" in agents
+    result = bus.publish("utility_task", "clean")
+    assert result == ["Performed clean"]
+    series = bus.publish("experiment_series", ["h1", "h2"])
+    assert series == [["Experimenting with h1", "Experimenting with h2"]]


### PR DESCRIPTION
## Summary
- add an `EventBus` for pub/sub messaging
- automatically load and register agents via `load_agents`
- expose new features through `core.__init__`
- update agent classes with registration hooks
- test that agent loading wires handlers correctly
- document the changes in the logbook and update the glossary

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c0afa588323b11157cc65fbf0af