### PR TITLE
Add VectorMemory module and docs

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .vector_memory import VectorMemory
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "VectorMemory"]

--- a/core/vector_memory.py
+++ b/core/vector_memory.py
@@ -1,0 +1,40 @@
+"""In-memory store for embeddings enabling similarity search."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Tuple
+import math
+
+
+class VectorMemory:
+    """Store vectors with associated items and perform similarity queries."""
+
+    def __init__(self) -> None:
+        """Initialize empty memory."""
+        self._data: List[Tuple[List[float], Any]] = []
+
+    def add(self, embedding: Iterable[float], item: Any) -> None:
+        """Add ``embedding`` and ``item`` to memory."""
+        self._data.append((list(embedding), item))
+
+    def query(self, embedding: Iterable[float], top_k: int = 1) -> List[Any]:
+        """Return up to ``top_k`` items most similar to ``embedding``."""
+        vector = list(embedding)
+        scored = [
+            (self._cosine_similarity(vector, stored), item)
+            for stored, item in self._data
+        ]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [item for _, item in scored[:top_k]]
+
+    @staticmethod
+    def _cosine_similarity(a: List[float], b: List[float]) -> float:
+        """Return cosine similarity between vectors ``a`` and ``b``."""
+        if not a or not b:
+            return 0.0
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(y * y for y in b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)

--- a/knowledge/emergent_insights.md
+++ b/knowledge/emergent_insights.md
@@ -6,3 +6,4 @@ defined in `glossary_reference.md`.
 
 * Insight 1: Memory recursion can transform raw data into knowledge.
 * Insight 2: Templates enforce consistent design, enabling scalability.
+* Insight 3: Vector similarity search provides contextual memory recall.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,20 +1,18 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
-- EidosCore
-- ExperimentAgent
-- MetaReflection
-- UtilityAgent
+-EidosCore
+-ExperimentAgent
+-MetaReflection
+-UtilityAgent
+-VectorMemory
 
 ## Functions
-- load_memory
-- main
-- save_memory
+-build_parser
+-load_memory
+-main
+-save_memory
 
 ## Constants
-- MANIFESTO_PROMPT
-- ROOT
+-MANIFESTO_PROMPT
+-ROOT

--- a/knowledge/recursive_patterns.md
+++ b/knowledge/recursive_patterns.md
@@ -12,3 +12,8 @@ documentation references are organized in the `glossary_reference.md`.
 ### Combined Cycle Pattern
 Use `process_cycle` to store an experience and immediately recurse,
 appending reflective insights in a single step.
+
+## Vector Memory Query Pattern
+1. Store embeddings with associated items via ``VectorMemory.add``.
+2. Provide a new embedding to ``VectorMemory.query``.
+3. Retrieve the most similar items based on cosine similarity.

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,17 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## VectorMemory Template
+```python
+class VectorMemory:
+    """Store embeddings and support similarity queries."""
+
+    def add(self, embedding: list[float], item: Any) -> None:
+        """Persist ``embedding`` and associate it with ``item``."""
+        pass
+
+    def query(self, embedding: list[float], top_k: int = 1) -> list[Any]:
+        """Return items most similar to ``embedding``."""
+        pass
+```

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -1,0 +1,15 @@
+from core.vector_memory import VectorMemory
+
+
+def test_add_and_query_single() -> None:
+    vm = VectorMemory()
+    vm.add([1.0, 0.0], "a")
+    assert vm.query([1.0, 0.0]) == ["a"]
+
+
+def test_query_orders_by_similarity() -> None:
+    vm = VectorMemory()
+    vm.add([1.0, 0.0], "first")
+    vm.add([0.0, 1.0], "second")
+    results = vm.query([0.9, 0.1], top_k=2)
+    assert results == ["first", "second"]


### PR DESCRIPTION
## Summary
- implement `VectorMemory` for storing embeddings and querying by similarity
- expose `VectorMemory` via `core.__init__`
- expand documentation with a VectorMemory template and new recursive pattern
- note insight about contextual recall and regenerate glossary
- test similarity query behavior

## Testing
- `black core/vector_memory.py tests/test_vector_memory.py core/__init__.py`
- `flake8 core/vector_memory.py tests/test_vector_memory.py core/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c0e36d883238e3c591d0e7128df