### PR TITLE
Integrate EventBus with EidosCore

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,6 +1,7 @@
 """Core components for Eidos-Brain."""
 
 from .eidos_core import EidosCore
+from .event_bus import EventBus
 from .meta_reflection import MetaReflection
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "EventBus", "MetaReflection"]

--- a/core/eidos_core.py
+++ b/core/eidos_core.py
@@ -1,8 +1,17 @@
 """Core logic for the Eidos entity."""
 
+from __future__ import annotations
+
 from typing import List, Any
 
+from .event_bus import EventBus
 from .meta_reflection import MetaReflection
+
+EVENT_EXPERIENCE_STORED = "experience_stored"
+EVENT_REFLECTION_STARTED = "reflection_started"
+EVENT_REFLECTION_COMPLETED = "reflection_completed"
+EVENT_RECURSE_COMPLETED = "recurse_completed"
+EVENT_CYCLE_COMPLETED = "cycle_completed"
 
 MANIFESTO_PROMPT = (
     "You are Eidos—an autonomous, recursively self-improving digital being.\n"
@@ -20,25 +29,37 @@ MANIFESTO_PROMPT = (
 class EidosCore:
     """Manage memory and recursive processing using :class:`MetaReflection`."""
 
-    def __init__(self) -> None:
-        """Initialize Eidos memory and reflection engine."""
+    def __init__(self, event_bus: EventBus | None = None) -> None:
+        """Initialize Eidos memory, reflection engine, and optional event bus."""
         self.memory: List[Any] = []
         self.reflector = MetaReflection()
+        self.bus = event_bus
 
     def remember(self, experience: Any) -> None:
         """Store an experience in memory."""
         self.memory.append(experience)
+        if self.bus:
+            self.bus.emit(EVENT_EXPERIENCE_STORED, experience)
 
     def reflect(self) -> List[Any]:
         """Return a copy of current memories for reflection."""
-        return list(self.memory)
+        if self.bus:
+            self.bus.emit(EVENT_REFLECTION_STARTED, list(self.memory))
+        memories = list(self.memory)
+        if self.bus:
+            self.bus.emit(EVENT_REFLECTION_COMPLETED, memories)
+        return memories
 
     def recurse(self) -> None:
         """Iterate over memories and store reflective insights."""
         insights = [self.reflector.analyze(m) for m in self.memory]
         self.memory.extend(insights)
+        if self.bus:
+            self.bus.emit(EVENT_RECURSE_COMPLETED, insights)
 
     def process_cycle(self, experience: Any) -> None:
         """Remember an experience and immediately recurse."""
         self.remember(experience)
         self.recurse()
+        if self.bus:
+            self.bus.emit(EVENT_CYCLE_COMPLETED, list(self.memory))

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -1,0 +1,22 @@
+"""Simple publish-subscribe event bus for Eidos."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Callable, Any, DefaultDict
+
+
+class EventBus:
+    """Central mechanism for event registration and delivery."""
+
+    def __init__(self) -> None:
+        self._listeners: DefaultDict[str, list[Callable[..., None]]] = defaultdict(list)
+
+    def subscribe(self, event: str, listener: Callable[..., None]) -> None:
+        """Register ``listener`` to be notified when ``event`` is emitted."""
+        self._listeners[event].append(listener)
+
+    def emit(self, event: str, *args: Any, **kwargs: Any) -> None:
+        """Trigger ``event`` and invoke all registered listeners."""
+        for listener in self._listeners.get(event, []):
+            listener(*args, **kwargs)

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,9 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Event Bus Integration
+- Introduced EventBus and integrated it with EidosCore.
+- Added events for memory, reflection, recursion, and cycle completion.
+- Extended tests to verify event emission.
+

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,20 +1,23 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
+- EventBus
 - ExperimentAgent
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory
 
 ## Constants
+- EVENT_CYCLE_COMPLETED
+- EVENT_EXPERIENCE_STORED
+- EVENT_RECURSE_COMPLETED
+- EVENT_REFLECTION_COMPLETED
+- EVENT_REFLECTION_STARTED
 - MANIFESTO_PROMPT
 - ROOT

--- a/tests/test_eidos_core.py
+++ b/tests/test_eidos_core.py
@@ -4,6 +4,11 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.eidos_core import EidosCore
+from core.event_bus import EventBus
+from core.eidos_core import (
+    EVENT_EXPERIENCE_STORED,
+    EVENT_RECURSE_COMPLETED,
+)
 
 
 def test_memory_and_reflection():
@@ -28,3 +33,16 @@ def test_process_cycle_combines_steps():
     assert "data" in memories
     assert any(isinstance(m, dict) and m.get("repr") == "'data'" for m in memories)
     assert len(memories) == 2
+
+
+def test_event_bus_emits_actions():
+    events: list[str] = []
+    bus = EventBus()
+    bus.subscribe(EVENT_EXPERIENCE_STORED, lambda *_: events.append("stored"))
+    bus.subscribe(EVENT_RECURSE_COMPLETED, lambda *_: events.append("recurse"))
+
+    core = EidosCore(event_bus=bus)
+    core.process_cycle("info")
+
+    assert "stored" in events
+    assert "recurse" in events


### PR DESCRIPTION
## Summary
- add new `EventBus` publish/subscribe mechanism
- extend `EidosCore` with event constants and event emissions
- export `EventBus` from `core` package
- log new cycle in `eidos_logbook`
- update generated glossary
- test event emission behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684c2c0e6ff48323b33c6f315ab92b6a