### PR TITLE
Add typed knowledge graph module

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .knowledge_graph import KnowledgeGraph
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "KnowledgeGraph"]

--- a/core/knowledge_graph.py
+++ b/core/knowledge_graph.py
@@ -1,0 +1,69 @@
+"""Typed knowledge graph utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class Node:
+    """Represents a typed entity in the knowledge graph."""
+
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class Fact:
+    """Single statement connecting two :class:`Node` objects."""
+
+    subject: Node
+    predicate: str
+    obj: Node
+
+
+class KnowledgeGraph:
+    """Store and query typed relationships between nodes."""
+
+    def __init__(self) -> None:
+        """Initialize an empty fact collection."""
+        self.facts: List[Fact] = []
+
+    def add_fact(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        *,
+        subject_type: str = "entity",
+        object_type: str = "entity",
+    ) -> None:
+        """Add a new fact to the graph."""
+        fact = Fact(Node(subject, subject_type), predicate, Node(obj, object_type))
+        self.facts.append(fact)
+
+    def query(
+        self,
+        *,
+        subject: Optional[str] = None,
+        predicate: Optional[str] = None,
+        obj: Optional[str] = None,
+        subject_type: Optional[str] = None,
+        object_type: Optional[str] = None,
+    ) -> List[Fact]:
+        """Return all facts matching the given parameters."""
+        results: List[Fact] = []
+        for fact in self.facts:
+            if subject is not None and fact.subject.name != subject:
+                continue
+            if subject_type is not None and fact.subject.type != subject_type:
+                continue
+            if predicate is not None and fact.predicate != predicate:
+                continue
+            if obj is not None and fact.obj.name != obj:
+                continue
+            if object_type is not None and fact.obj.type != object_type:
+                continue
+            results.append(fact)
+        return results

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,16 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
+- Fact
+- KnowledgeGraph
 - MetaReflection
+- Node
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,39 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Knowledge Graph Template
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Node:
+    name: str
+    type: str
+
+@dataclass(frozen=True)
+class Fact:
+    subject: Node
+    predicate: str
+    obj: Node
+
+class KnowledgeGraph:
+    def __init__(self) -> None:
+        self.facts: list[Fact] = []
+
+    def add_fact(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        *,
+        subject_type: str = "entity",
+        object_type: str = "entity",
+    ) -> None:
+        self.facts.append(
+            Fact(Node(subject, subject_type), predicate, Node(obj, object_type))
+        )
+
+    def query(self, subject: str | None = None, predicate: str | None = None) -> list[Fact]:
+        return [f for f in self.facts if f.subject.name == subject and f.predicate == predicate]
+```

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,25 @@
+from core.knowledge_graph import KnowledgeGraph
+
+
+def test_add_and_query_fact() -> None:
+    graph = KnowledgeGraph()
+    graph.add_fact("Alice", "knows", "Bob", subject_type="person", object_type="person")
+    results = graph.query(subject="Alice", predicate="knows")
+    assert len(results) == 1
+    fact = results[0]
+    assert fact.subject.name == "Alice"
+    assert fact.obj.name == "Bob"
+    assert fact.subject.type == "person"
+    assert fact.obj.type == "person"
+
+
+def test_query_filters() -> None:
+    graph = KnowledgeGraph()
+    graph.add_fact("Alice", "knows", "Bob", subject_type="person", object_type="person")
+    graph.add_fact("Alice", "owns", "Car", subject_type="person", object_type="object")
+    know_results = graph.query(predicate="knows")
+    own_results = graph.query(object_type="object")
+    assert len(know_results) == 1
+    assert know_results[0].predicate == "knows"
+    assert len(own_results) == 1
+    assert own_results[0].predicate == "owns"


### PR DESCRIPTION
## Summary
- implement `KnowledgeGraph` with typed nodes and fact storage
- expose new graph utilities via `core.__init__`
- add example template for knowledge graphs
- regenerate glossary to include the new classes
- test basic fact addition and query

## Testing
- `black --check --diff core agents labs tools tests`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c0ef4808323bd26fd37f38afabc