### PR TITLE
Add persistence utilities for vectors and graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,17 @@ Follow the prompts to add experiences, view memories, recurse, and exit.
 
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>
+
+### Persistence Utilities
+Use the helpers in `core.persistence` to save and load vector memories or knowledge graphs:
+
+```python
+from core.persistence import (
+    save_vector_memory,
+    load_vector_memory,
+    save_knowledge_graph,
+    load_knowledge_graph,
+)
+```
+
+Each function accepts a `pathlib.Path` and handles JSON serialization.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,18 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .persistence import (
+    save_vector_memory,
+    load_vector_memory,
+    save_knowledge_graph,
+    load_knowledge_graph,
+)
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = [
+    "EidosCore",
+    "MetaReflection",
+    "save_vector_memory",
+    "load_vector_memory",
+    "save_knowledge_graph",
+    "load_knowledge_graph",
+]

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -1,0 +1,34 @@
+"""Utilities for persisting vector memories and knowledge graph state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence, Mapping, MutableMapping, List, Dict
+
+Vector = Sequence[Sequence[float]]
+Graph = MutableMapping[str, List[str]]
+
+
+def save_vector_memory(memory: Vector, path: Path) -> None:
+    """Persist ``memory`` as JSON to ``path``."""
+    path.write_text(json.dumps(memory))
+
+
+def load_vector_memory(path: Path) -> List[List[float]]:
+    """Load vector memory from ``path`` or return an empty list."""
+    if path.exists():
+        return json.loads(path.read_text())
+    return []
+
+
+def save_knowledge_graph(graph: Mapping[str, Sequence[str]], path: Path) -> None:
+    """Persist a knowledge graph mapping to ``path`` as JSON."""
+    path.write_text(json.dumps({k: list(v) for k, v in graph.items()}))
+
+
+def load_knowledge_graph(path: Path) -> Dict[str, List[str]]:
+    """Load a knowledge graph from ``path`` or return an empty dict."""
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,10 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Persistence Utilities
+- Added `core/persistence.py` with save/load helpers for vectors and graphs
+- Exported new utilities in `core/__init__.py`
+- Created tests verifying round-trip and missing-file behavior
+
+**Next Target:** Document graph structures and integrate persistence into tutorial

--- a/knowledge/emergent_insights.md
+++ b/knowledge/emergent_insights.md
@@ -6,3 +6,4 @@ defined in `glossary_reference.md`.
 
 * Insight 1: Memory recursion can transform raw data into knowledge.
 * Insight 2: Templates enforce consistent design, enabling scalability.
+* Insight 3: Persisted vectors and graphs ensure continuity across sessions.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,9 +1,5 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
@@ -11,9 +7,14 @@ Refer back to `templates.md` for code usage examples and to
 - UtilityAgent
 
 ## Functions
+- build_parser
+- load_knowledge_graph
 - load_memory
+- load_vector_memory
 - main
+- save_knowledge_graph
 - save_memory
+- save_vector_memory
 
 ## Constants
 - MANIFESTO_PROMPT

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.persistence import (
+    save_vector_memory,
+    load_vector_memory,
+    save_knowledge_graph,
+    load_knowledge_graph,
+)
+
+
+def test_vector_memory_roundtrip(tmp_path):
+    memory = [[0.1, 0.2], [3.4, 5.6]]
+    file = tmp_path / "vectors.json"
+    save_vector_memory(memory, file)
+    loaded = load_vector_memory(file)
+    assert loaded == memory
+
+
+def test_vector_memory_missing(tmp_path):
+    file = tmp_path / "missing.json"
+    loaded = load_vector_memory(file)
+    assert loaded == []
+
+
+def test_graph_roundtrip(tmp_path):
+    graph = {"A": ["B"], "B": ["A", "C"]}
+    file = tmp_path / "graph.json"
+    save_knowledge_graph(graph, file)
+    loaded = load_knowledge_graph(file)
+    assert loaded == graph
+
+
+def test_graph_missing(tmp_path):
+    file = tmp_path / "none.json"
+    loaded = load_knowledge_graph(file)
+    assert loaded == {}


### PR DESCRIPTION
## Summary
- persist vector memories and knowledge graphs with JSON helpers
- expose new helpers via `core.__init__`
- document persistence utilities in README
- track new cycle and insight
- generate updated glossary
- test persistence round-trips

## Testing
- `pytest -q`
- `pytest tests/test_glossary.py -q`


------
https://chatgpt.com/codex/tasks/task_b_684c2c111e788323a2e34af81b58ff90