### PR TITLE
Implement Engine orchestrator

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,12 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .engine import Engine
+from .event_bus import EventBus
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = [
+    "EidosCore",
+    "MetaReflection",
+    "Engine",
+    "EventBus",
+]

--- a/core/engine.py
+++ b/core/engine.py
@@ -1,0 +1,51 @@
+"""Orchestrates core components, agents, and events."""
+
+from typing import Any, Callable
+
+from .eidos_core import EidosCore
+from .event_bus import EventBus
+from agents import UtilityAgent, ExperimentAgent
+
+
+class Engine:
+    """Central coordinator providing high-level interactions."""
+
+    def __init__(self) -> None:
+        self.core = EidosCore()
+        self.utility_agent = UtilityAgent()
+        self.experiment_agent = ExperimentAgent()
+        self.bus = EventBus()
+
+    def add_experience(self, experience: Any) -> None:
+        """Store ``experience`` via :class:`EidosCore`."""
+        self.core.remember(experience)
+        self.bus.publish("experience_added", experience)
+
+    def run_cycle(self, experience: Any) -> None:
+        """Execute a full cycle of storing and reflecting."""
+        self.core.process_cycle(experience)
+        self.bus.publish("cycle_complete", experience)
+
+    def reflect(self) -> list[Any]:
+        """Return a snapshot of current memories."""
+        return self.core.reflect()
+
+    def run_experiment(self, hypothesis: str) -> str:
+        """Delegate to :class:`ExperimentAgent` and emit event."""
+        result = self.experiment_agent.run(hypothesis)
+        self.bus.publish("experiment_run", hypothesis, result)
+        return result
+
+    def perform_task(self, task: str) -> str:
+        """Delegate to :class:`UtilityAgent` and emit event."""
+        result = self.utility_agent.perform_task(task)
+        self.bus.publish("task_performed", task, result)
+        return result
+
+    def on(self, event: str, listener: Callable[..., None]) -> None:
+        """Subscribe ``listener`` to ``event``."""
+        self.bus.subscribe(event, listener)
+
+    def emit(self, event: str, *args: Any, **kwargs: Any) -> None:
+        """Manually publish an event."""
+        self.bus.publish(event, *args, **kwargs)

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -1,0 +1,20 @@
+"""Minimal event bus for Eidos components."""
+
+from collections import defaultdict
+from typing import Callable, Any, DefaultDict, List
+
+
+class EventBus:
+    """Publish and subscribe to named events."""
+
+    def __init__(self) -> None:
+        self._listeners: DefaultDict[str, List[Callable[..., None]]] = defaultdict(list)
+
+    def subscribe(self, event: str, listener: Callable[..., None]) -> None:
+        """Register ``listener`` for ``event``."""
+        self._listeners[event].append(listener)
+
+    def publish(self, event: str, *args: Any, **kwargs: Any) -> None:
+        """Invoke listeners attached to ``event``."""
+        for listener in list(self._listeners.get(event, [])):
+            listener(*args, **kwargs)

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -6,11 +6,14 @@ Refer back to `templates.md` for code usage examples and to
 
 ## Classes
 - EidosCore
+- Engine
+- EventBus
 - ExperimentAgent
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,29 @@
+from core.engine import Engine
+from core.eidos_core import EidosCore
+from agents import UtilityAgent, ExperimentAgent
+
+
+def test_engine_initializes_components() -> None:
+    engine = Engine()
+    assert isinstance(engine.core, EidosCore)
+    assert isinstance(engine.utility_agent, UtilityAgent)
+    assert isinstance(engine.experiment_agent, ExperimentAgent)
+    assert hasattr(engine, "bus")
+
+
+def test_engine_event_bus() -> None:
+    engine = Engine()
+    called = []
+
+    def listener(data: str) -> None:
+        called.append(data)
+
+    engine.on("experience_added", listener)
+    engine.add_experience("test")
+    assert called == ["test"]
+
+
+def test_engine_delegates_tasks() -> None:
+    engine = Engine()
+    assert engine.perform_task("clean") == "Performed clean"
+    assert engine.run_experiment("X") == "Experimenting with X"


### PR DESCRIPTION
## Summary
- introduce EventBus for simple pub/sub communication
- add Engine class tying core, agents, and events together
- expose Engine and EventBus from the core package
- regenerate glossary to include new symbols
- test Engine initialization, event bus usage, and delegation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684c2c1190dc8323a78e95da5bcec0ac