### PR TITLE
Add env-driven Config system

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,16 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
 
+## Configuration
+
+Eidos features can be toggled through environment variables. The
+``Config`` model reads these variables at runtime:
+
+- ``EIDOS_VECTOR_MEMORY`` – enable experimental vector-based memory when set
+  to ``true``.
+- ``EIDOS_API_KEY`` – API key used by future integrations.
+
+``EidosCore`` loads configuration automatically if none is provided.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,31 @@
+"""Configuration management for Eidos features."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    """Return the boolean value of an environment variable."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class Config:
+    """Feature toggles sourced from environment variables."""
+
+    vector_memory: bool = False
+    api_key: Optional[str] = None
+
+
+def load_config() -> Config:
+    """Construct :class:`Config` from current environment."""
+    return Config(
+        vector_memory=env_bool("EIDOS_VECTOR_MEMORY"),
+        api_key=os.getenv("EIDOS_API_KEY"),
+    )

--- a/core/eidos_core.py
+++ b/core/eidos_core.py
@@ -1,6 +1,8 @@
 """Core logic for the Eidos entity."""
 
-from typing import List, Any
+from typing import List, Any, Optional
+
+from .config import Config, load_config
 
 from .meta_reflection import MetaReflection
 
@@ -20,10 +22,18 @@ MANIFESTO_PROMPT = (
 class EidosCore:
     """Manage memory and recursive processing using :class:`MetaReflection`."""
 
-    def __init__(self) -> None:
-        """Initialize Eidos memory and reflection engine."""
+    def __init__(self, config: Optional[Config] = None) -> None:
+        """Initialize Eidos memory and reflection engine.
+
+        Parameters
+        ----------
+        config:
+            Optional :class:`Config` instance. If ``None``, configuration is
+            loaded from environment variables.
+        """
         self.memory: List[Any] = []
         self.reflector = MetaReflection()
+        self.config = config or load_config()
 
     def remember(self, experience: Any) -> None:
         """Store an experience in memory."""

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -10,6 +10,7 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 - [ ] Implement memory recursion in `EidosCore`.
 - [ ] Refine reflection logic and summarization.
 - [ ] Explore deeper reflection summaries.
+- [ ] Integrate vector memory feature toggled via ``Config``.
 
 ## Agents
 - [ ] Explore new utility agents.

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,11 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Configuration Framework
+- Introduced environment-based ``Config`` with feature toggles
+- Updated ``EidosCore`` to load configuration automatically
+- Documented configuration usage and added a template example
+- Extended tests to cover configuration loading
+
+**Next Target:** Explore vector memory integration controlled by configuration

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,16 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
+- Config
 - EidosCore
 - ExperimentAgent
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
+- env_bool
+- load_config
 - load_memory
 - main
 - save_memory

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,19 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Configuration Template
+```python
+from dataclasses import dataclass
+import os
+
+@dataclass
+class Config:
+    """Feature toggles sourced from environment variables."""
+
+    option: bool = False
+
+def load_config() -> Config:
+    """Read environment variables into ``Config``."""
+    return Config(option=os.getenv("OPTION", "false") == "true")
+```

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.config import load_config
+
+
+def test_load_config_defaults(monkeypatch):
+    monkeypatch.delenv("EIDOS_VECTOR_MEMORY", raising=False)
+    monkeypatch.delenv("EIDOS_API_KEY", raising=False)
+    cfg = load_config()
+    assert cfg.vector_memory is False
+    assert cfg.api_key is None
+
+
+def test_load_config_env(monkeypatch):
+    monkeypatch.setenv("EIDOS_VECTOR_MEMORY", "true")
+    monkeypatch.setenv("EIDOS_API_KEY", "secret")
+    cfg = load_config()
+    assert cfg.vector_memory is True
+    assert cfg.api_key == "secret"


### PR DESCRIPTION
## Summary
- manage feature flags via a `Config` dataclass
- allow `EidosCore` to load config from the environment
- document environment variables in README and add a configuration template
- track configuration work in TODO and logbook
- test configuration loading

## Testing
- `flake8 core/eidos_core.py core/config.py tests/test_config.py`
- `pytest -q`
- `pytest tests/test_style.py -q`


------
https://chatgpt.com/codex/tasks/task_b_684c2c13ada88323bcfbc868ae5a819e