### PR TITLE
Add Typer-based CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,15 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
 
+### Command-Line Interface
+
+`tools/eidos_cli.py` provides a Typer-based CLI with multiple subcommands:
+
+```bash
+python tools/eidos_cli.py --help
+```
+
+Subcommands include `add-memory`, `reflect`, `run-agent`, and `interactive`.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -16,7 +16,7 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 - [ ] Expand agent features and tests.
 
 ## Tools
-- [ ] Build interactive CLI utilities for rapid experimentation.
+- [x] Build interactive CLI utilities for rapid experimentation.
 - [ ] Expand existing CLI tools.
 
 ## Docs

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -11,10 +11,25 @@ Refer back to `templates.md` for code usage examples and to
 - UtilityAgent
 
 ## Functions
+- add_memory
+- append_entry
+- build_parser
+- extract_symbols
+- format_entry
+- interactive
 - load_memory
 - main
+- next_cycle_number
+- read_logbook
+- reflect
+- run_agent
 - save_memory
+- scan_codebase
+- write_glossary
 
 ## Constants
+- LOGBOOK_PATH
 - MANIFESTO_PROMPT
+- OUTPUT_PATH
 - ROOT
+- SOURCE_DIRS

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ rich
 pytest
 black
 flake8
+
+typer

--- a/tests/test_eidos_cli.py
+++ b/tests/test_eidos_cli.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from typer.testing import CliRunner
+from tools import eidos_cli
+from rich.prompt import Prompt
+from unittest.mock import patch
+
+
+runner = CliRunner()
+
+
+def test_add_and_reflect() -> None:
+    result = runner.invoke(eidos_cli.app, ["add-memory", "hello"])
+    assert result.exit_code == 0
+    result = runner.invoke(eidos_cli.app, ["reflect"])
+    assert "hello" in result.stdout
+
+
+def test_run_agent_utility() -> None:
+    result = runner.invoke(eidos_cli.app, ["run-agent", "utility", "build"])
+    assert "Performed build" in result.stdout
+
+
+def test_interactive_exit() -> None:
+    with patch.object(Prompt, "ask", side_effect=["exit"]):
+        result = runner.invoke(eidos_cli.app, ["interactive"])
+    assert result.exit_code == 0

--- a/tools/eidos_cli.py
+++ b/tools/eidos_cli.py
@@ -1,0 +1,79 @@
+"""Typer-based CLI for Eidos operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+
+from core.eidos_core import EidosCore
+from agents import UtilityAgent, ExperimentAgent
+
+
+app = typer.Typer(help="Eidos command-line interface")
+console = Console()
+core = EidosCore()
+
+
+def load_memory(path: Path) -> None:
+    """Load memories from ``path`` if it exists."""
+    if path.exists():
+        core.memory = path.read_text().splitlines()
+        console.print(f"Loaded {len(core.memory)} memories from {path}.")
+
+
+def save_memory(path: Path) -> None:
+    """Persist memories to ``path``."""
+    path.write_text("\n".join(map(str, core.memory)))
+    console.print(f"Memories saved to {path}.")
+
+
+@app.command()
+def add_memory(data: str) -> None:
+    """Add ``data`` to memory."""
+    core.remember(data)
+    console.print("Memory added.")
+
+
+@app.command()
+def reflect() -> None:
+    """Display all current memories."""
+    console.print(core.reflect())
+
+
+@app.command()
+def run_agent(agent: str, task: str) -> None:
+    """Run a specific agent with ``task``."""
+    if agent == "utility":
+        result = UtilityAgent().perform_task(task)
+    elif agent == "experiment":
+        result = ExperimentAgent().run(task)
+    else:
+        raise typer.BadParameter("agent must be 'utility' or 'experiment'")
+    console.print(result)
+
+
+@app.command()
+def interactive() -> None:
+    """Enter an interactive loop for memory operations."""
+    console.print("[bold underline]Interactive Mode[/]")
+    while True:
+        action = Prompt.ask(
+            "Action", choices=["add", "reflect", "recurse", "exit"], default="exit"
+        )
+        if action == "add":
+            experience = Prompt.ask("Enter experience")
+            core.remember(experience)
+            console.print("Experience stored.")
+        elif action == "reflect":
+            console.print(core.reflect())
+        elif action == "recurse":
+            core.recurse()
+            console.print("Reflection complete.")
+        elif action == "exit":
+            break
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -6,7 +6,7 @@ import ast
 from pathlib import Path
 
 OUTPUT_PATH = Path("knowledge/glossary_reference.md")
-SOURCE_DIRS = ["core", "agents", "labs"]
+SOURCE_DIRS = ["core", "agents", "labs", "tools"]
 
 
 def extract_symbols(path: Path) -> list[tuple[str, str]]:
@@ -38,7 +38,14 @@ def scan_codebase() -> dict[str, list[str]]:
 def write_glossary(glossary: dict[str, list[str]]) -> None:
     """Write collected symbols to the glossary file."""
     plural_map = {"class": "Classes", "function": "Functions", "constant": "Constants"}
-    lines = ["# Glossary Reference", ""]
+    lines = [
+        "# Glossary Reference",
+        "",
+        "This generated list standardizes terminology used across all documentation.",
+        "Refer back to `templates.md` for code usage examples and to",
+        "`recursive_patterns.md` for context on how these terms interact recursively.",
+        "",
+    ]
     for kind, names in glossary.items():
         header = plural_map.get(kind, kind.title() + "s")
         lines.append(f"## {header}")


### PR DESCRIPTION
## Summary
- add a Typer CLI with commands for adding memory, reflecting, running agents, and interactive mode
- track CLI work in TODO docs
- extend glossary generation to include tools and regenerate list
- document CLI usage in the README
- include automated tests for the new CLI

## Testing
- `black tools/eidos_cli.py tests/test_eidos_cli.py tools/generate_glossary.py`
- `flake8 tools/eidos_cli.py tests/test_eidos_cli.py tools/generate_glossary.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c159e548323af9b6f492d1c06e5