### PR TITLE
Add logging configuration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Run wild. Evolve forever.
 - **agents/**: specialized actors for experiments and utilities
 - **knowledge/**: evolving documentation and design patterns
 - **labs/**: sandbox for rapid prototyping
+- **core/logging_config.py**: unified logging setup for all modules
 
 Within `labs/`, `tutorial_app.py` offers an interactive introduction to
 `EidosCore`.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .logging_config import configure_logging
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "configure_logging"]

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -1,0 +1,43 @@
+"""Central logging configuration for the Eidos project."""
+
+from __future__ import annotations
+
+import logging
+from logging import Logger
+
+DEFAULT_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def configure_logging(level: int = logging.INFO, log_file: str | None = None) -> Logger:
+    """Configure and return the root logger.
+
+    Parameters
+    ----------
+    level:
+        Log level applied to the root logger.
+    log_file:
+        Optional file path to also receive log output.
+
+    Returns
+    -------
+    Logger
+        The configured root logger.
+    """
+    logger = logging.getLogger()
+    logger.setLevel(level)
+
+    formatter = logging.Formatter(DEFAULT_FORMAT)
+
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    return logger

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,9 +1,5 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
@@ -11,10 +7,13 @@ Refer back to `templates.md` for code usage examples and to
 - UtilityAgent
 
 ## Functions
+- build_parser
+- configure_logging
 - load_memory
 - main
 - save_memory
 
 ## Constants
+- DEFAULT_FORMAT
 - MANIFESTO_PROMPT
 - ROOT

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.logging_config import configure_logging, DEFAULT_FORMAT
+
+
+def test_configure_logging(tmp_path: Path) -> None:
+    log_file = tmp_path / "out.log"
+    logger = configure_logging(logging.DEBUG, log_file=str(log_file))
+
+    logger.debug("message")
+
+    content = log_file.read_text()
+    assert "message" in content
+    assert logger.level == logging.DEBUG
+    assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
+    assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+    for handler in logger.handlers:
+        assert handler.formatter._fmt == DEFAULT_FORMAT


### PR DESCRIPTION
## Summary
- provide centralized logging via `core.logging_config`
- export `configure_logging` through the core package
- document logging config in `README`
- update glossary
- test logging configuration

## Testing
- `pytest -q`
- `pytest tests/test_style.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c155c648323a90620ddc761c9d8