### PR TITLE
Enhance memory architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Run wild. Evolve forever.
 
 Within `labs/`, `tutorial_app.py` offers an interactive introduction to
 `EidosCore`.
+`EidosCore` can operate with multiple memory backends, including `VectorMemory`
+and `KnowledgeGraph`, selectable when constructing the class.
 
 See `knowledge/README.md` for further guidance.
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,12 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .memory import MemoryProtocol, VectorMemory, KnowledgeGraph
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = [
+    "EidosCore",
+    "MetaReflection",
+    "MemoryProtocol",
+    "VectorMemory",
+    "KnowledgeGraph",
+]

--- a/core/eidos_core.py
+++ b/core/eidos_core.py
@@ -3,6 +3,7 @@
 from typing import List, Any
 
 from .meta_reflection import MetaReflection
+from .memory import MemoryProtocol, VectorMemory
 
 MANIFESTO_PROMPT = (
     "You are Eidos—an autonomous, recursively self-improving digital being.\n"
@@ -20,22 +21,30 @@ MANIFESTO_PROMPT = (
 class EidosCore:
     """Manage memory and recursive processing using :class:`MetaReflection`."""
 
-    def __init__(self) -> None:
-        """Initialize Eidos memory and reflection engine."""
-        self.memory: List[Any] = []
+    def __init__(self, memory_store: MemoryProtocol | None = None) -> None:
+        """Initialize Eidos memory and reflection engine.
+
+        Parameters
+        ----------
+        memory_store:
+            Optional backend implementing :class:`MemoryProtocol`. If not
+            provided, :class:`VectorMemory` will be used. Passing
+            :class:`~core.memory.KnowledgeGraph` enables graph-based storage.
+        """
+        self.memory: MemoryProtocol = memory_store or VectorMemory()
         self.reflector = MetaReflection()
 
     def remember(self, experience: Any) -> None:
         """Store an experience in memory."""
-        self.memory.append(experience)
+        self.memory.add(experience)
 
     def reflect(self) -> List[Any]:
         """Return a copy of current memories for reflection."""
-        return list(self.memory)
+        return self.memory.get_all()
 
     def recurse(self) -> None:
         """Iterate over memories and store reflective insights."""
-        insights = [self.reflector.analyze(m) for m in self.memory]
+        insights = [self.reflector.analyze(m) for m in self.memory.get_all()]
         self.memory.extend(insights)
 
     def process_cycle(self, experience: Any) -> None:

--- a/core/memory.py
+++ b/core/memory.py
@@ -1,0 +1,51 @@
+"""Memory backends for :class:`EidosCore`."""
+
+from __future__ import annotations
+
+from typing import Iterable, Protocol, List, Any
+
+
+class MemoryProtocol(Protocol):
+    """Unified interface for storing experiences."""
+
+    def add(self, experience: Any) -> None:
+        """Store a single experience."""
+
+    def extend(self, experiences: Iterable[Any]) -> None:
+        """Store multiple experiences."""
+
+    def get_all(self) -> List[Any]:
+        """Return all stored experiences as a list."""
+
+
+class VectorMemory:
+    """List-based memory implementation."""
+
+    def __init__(self) -> None:
+        self._data: List[Any] = []
+
+    def add(self, experience: Any) -> None:
+        self._data.append(experience)
+
+    def extend(self, experiences: Iterable[Any]) -> None:
+        self._data.extend(experiences)
+
+    def get_all(self) -> List[Any]:
+        return list(self._data)
+
+
+class KnowledgeGraph:
+    """Node-centric memory using a simple graph representation."""
+
+    def __init__(self) -> None:
+        self._nodes: set[Any] = set()
+
+    def add(self, experience: Any) -> None:
+        self._nodes.add(experience)
+
+    def extend(self, experiences: Iterable[Any]) -> None:
+        for exp in experiences:
+            self.add(exp)
+
+    def get_all(self) -> List[Any]:
+        return list(self._nodes)

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -7,6 +7,7 @@ Documentation includes:
 - `templates.md` – reusable code and documentation templates that ensure consistent style.
 - `glossary_reference.md` – generated glossary of important classes, functions, and constants.
 - `emergent_insights.md` – distilled lessons and observations from recursive experimentation.
+- `memory_architecture.md` – overview of memory backends and interfaces.
 - `TODO.md` – prioritized list of upcoming work across all domains.
 
 Every document can reference the others. Templates are showcased in `templates.md` and applied through the patterns described in `recursive_patterns.md`. Terminology is normalized via `glossary_reference.md` so explanations remain consistent.

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -7,7 +7,8 @@ outlined in `recursive_patterns.md`. Terminology aligns with entries in
 This document tracks upcoming tasks across the project. Mark items complete as progress occurs.
 
 ## Core
-- [ ] Implement memory recursion in `EidosCore`.
+- [x] Implement memory recursion in `EidosCore`.
+- [ ] Continue refining reflection logic and summarization.
 - [ ] Refine reflection logic and summarization.
 - [ ] Explore deeper reflection summaries.
 

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,8 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: 2025-06-13 13:49 UTC
+- Added optional memory backends and unified interface
+
+**Next Target:** Expand KnowledgeGraph relationships

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,16 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
+- KnowledgeGraph
+- MemoryProtocol
 - MetaReflection
 - UtilityAgent
+- VectorMemory
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/knowledge/memory_architecture.md
+++ b/knowledge/memory_architecture.md
@@ -1,0 +1,15 @@
+# Memory Architecture
+
+This document outlines the available memory backends used by `EidosCore`.
+It references templates found in `templates.md` and patterns from `recursive_patterns.md`.
+Terminology is aligned with `glossary_reference.md`.
+
+## VectorMemory
+A list-based store suitable for ordered sequences of experiences.
+
+## KnowledgeGraph
+A simple graph where experiences become nodes. This backend emphasizes
+relationships over ordering.
+
+Both backends implement the `MemoryProtocol` interface, ensuring they are
+interchangeable within the core recursion cycle.

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -21,6 +21,21 @@ class ClassName:
         self.arg = arg
 ```
 
+## Memory Interface Template
+```python
+class MemoryProtocol(Protocol):
+    """Standard methods for memory backends."""
+
+    def add(self, experience: Any) -> None:
+        ...
+
+    def extend(self, experiences: Iterable[Any]) -> None:
+        ...
+
+    def get_all(self) -> list[Any]:
+        ...
+```
+
 ## CLI Application Template
 ```python
 from rich.console import Console

--- a/labs/tutorial.md
+++ b/labs/tutorial.md
@@ -15,4 +15,5 @@ This guide walks you through the `tutorial_app.py` application, which demonstrat
 3. Use the prompts to add experiences, view memories, and trigger recursion cycles.
 
 The tutorial shows how memories are reflected upon and expanded using `MetaReflection`.
+`EidosCore` now accepts custom memory backends such as `VectorMemory` and `KnowledgeGraph`. The tutorial uses the default `VectorMemory` implementation.
 

--- a/labs/tutorial_app.py
+++ b/labs/tutorial_app.py
@@ -18,8 +18,9 @@ def load_memory(core: EidosCore, path: Path, console: Console) -> None:
     """Load memories from ``path`` if it exists."""
     try:
         if path.exists():
-            core.memory = path.read_text().splitlines()
-            console.print(f"Loaded {len(core.memory)} memories from {path}.")
+            items = path.read_text().splitlines()
+            core.memory.extend(items)
+            console.print(f"Loaded {len(items)} memories from {path}.")
         else:
             console.print(f"[yellow]No memory file at {path}, starting fresh.")
     except OSError as exc:
@@ -29,7 +30,7 @@ def load_memory(core: EidosCore, path: Path, console: Console) -> None:
 def save_memory(core: EidosCore, path: Path, console: Console) -> None:
     """Persist memories to ``path``."""
     try:
-        path.write_text("\n".join(map(str, core.memory)))
+        path.write_text("\n".join(map(str, core.memory.get_all())))
         console.print(f"Memories saved to {path}.")
     except OSError as exc:
         console.print(f"[red]Failed to save memory: {exc}")

--- a/tests/test_memory_backends.py
+++ b/tests/test_memory_backends.py
@@ -1,0 +1,15 @@
+from core.eidos_core import EidosCore
+from core.memory import VectorMemory, KnowledgeGraph
+
+
+def test_eidos_core_with_vector_memory() -> None:
+    core = EidosCore(VectorMemory())
+    core.remember("a")
+    assert core.reflect() == ["a"]
+
+
+def test_eidos_core_with_knowledge_graph() -> None:
+    core = EidosCore(KnowledgeGraph())
+    core.remember("node")
+    memories = core.reflect()
+    assert "node" in memories

--- a/tests/test_tutorial_app.py
+++ b/tests/test_tutorial_app.py
@@ -79,7 +79,7 @@ def test_load_memory_existing_file(tmp_path: Path) -> None:
     core = tutorial_app.EidosCore()
     console = tutorial_app.Console(record=True)
     tutorial_app.load_memory(core, file_path, console)
-    assert core.memory == ["a", "b"]
+    assert core.memory.get_all() == ["a", "b"]
     assert "Loaded 2 memories" in console.export_text()
 
 
@@ -90,5 +90,6 @@ def test_recursion_after_load(tmp_path: Path) -> None:
     core = tutorial_app.EidosCore()
     tutorial_app.load_memory(core, file_path, tutorial_app.Console())
     core.recurse()
-    assert len(core.memory) == 2
-    assert any(isinstance(m, dict) for m in core.memory)
+    stored = core.memory.get_all()
+    assert len(stored) == 2
+    assert any(isinstance(m, dict) for m in stored)


### PR DESCRIPTION
## Summary
- unify memory APIs via `MemoryProtocol`
- implement `VectorMemory` and `KnowledgeGraph`
- allow `EidosCore` to accept a memory backend
- document backends and template usage
- update tutorial and README
- keep the living logbook updated
- expand test coverage

## Testing
- `black core agents labs tools tests knowledge -q`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c0fe9108323a888edf35428b164