### PR TITLE
Add Engine and interactive REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,15 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
 
+### Running the REPL
+
+`repl.py` provides a Rich-powered shell backed by the new `Engine`:
+
+```bash
+python labs/repl.py [--load PATH] [--save PATH]
+```
+
+State persists within a session and may be loaded or saved between runs.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/core/engine.py
+++ b/core/engine.py
@@ -1,0 +1,27 @@
+"""Execution engine orchestrating operations for :class:`EidosCore`."""
+
+from __future__ import annotations
+
+
+from .eidos_core import EidosCore
+
+
+class Engine:
+    """Perform actions using an internal :class:`EidosCore` instance."""
+
+    def __init__(self) -> None:
+        """Initialize the engine with its own core."""
+        self.core = EidosCore()
+
+    def execute(self, command: str, *args: str) -> str:
+        """Execute ``command`` with ``args`` and return a response."""
+        if command == "add":
+            experience = " ".join(args)
+            self.core.remember(experience)
+            return "Experience added."
+        if command == "reflect":
+            return repr(self.core.reflect())
+        if command == "recurse":
+            self.core.recurse()
+            return "Recursion complete."
+        return "Unknown command"

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -16,7 +16,7 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 - [ ] Expand agent features and tests.
 
 ## Tools
-- [ ] Build interactive CLI utilities for rapid experimentation.
+- [x] Build interactive CLI utilities for rapid experimentation.
 - [ ] Expand existing CLI tools.
 
 ## Docs
@@ -27,4 +27,4 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 ## Tests
 - [ ] Create comprehensive tests for core and agents.
 - [ ] Enforce style checks with black and flake8.
-- [ ] Expand coverage for CLI tools and reflection logic.
+- [x] Expand coverage for CLI tools and reflection logic.

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,8 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: 2025-06-13 13:50 UTC
+- Added Engine and Rich-based REPL
+
+**Next Target:** Test persistent interactive shell

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,15 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
+- Engine
 - ExperimentAgent
 - MetaReflection
+- REPL
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/labs/repl.py
+++ b/labs/repl.py
@@ -1,0 +1,62 @@
+"""Interactive REPL powered by :class:`rich` and the :class:`Engine`."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rich.console import Console
+from rich.prompt import Prompt
+
+from core.engine import Engine
+from labs.tutorial_app import load_memory, save_memory
+
+
+class REPL:
+    """Run a simple read-eval-print loop using an :class:`Engine`."""
+
+    def __init__(self, engine: Engine, console: Console | None = None) -> None:
+        self.engine = engine
+        self.console = console or Console()
+
+    def loop(self) -> None:
+        """Begin interactive input processing."""
+        self.console.print("[bold underline]Eidos REPL[/]")
+        while True:
+            cmdline = Prompt.ask("?>").strip()
+            if not cmdline:
+                continue
+            command, *args = cmdline.split()
+            if command in {"exit", "quit"}:
+                break
+            output = self.engine.execute(command, *args)
+            self.console.print(output)
+
+
+def build_parser() -> ArgumentParser:
+    """Return an argument parser for the CLI."""
+    parser = ArgumentParser(description="Eidos interactive REPL")
+    parser.add_argument("--load", help="Memory file to load", default=None)
+    parser.add_argument("--save", help="Memory file to save on exit", default=None)
+    return parser
+
+
+def main(load: str | None = None, save: str | None = None) -> None:
+    """Entry point for the REPL application."""
+    console = Console()
+    engine = Engine()
+    if load:
+        load_memory(engine.core, Path(load), console)
+    REPL(engine, console).loop()
+    if save:
+        save_memory(engine.core, Path(save), console)
+
+
+if __name__ == "__main__":
+    args = build_parser().parse_args()
+    main(load=args.load, save=args.save)

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+from pathlib import Path
+import subprocess
+import sys
+
+from core.engine import Engine
+from labs import repl
+
+
+def test_engine_add_and_reflect() -> None:
+    engine = Engine()
+    engine.execute("add", "note")
+    result = engine.execute("reflect")
+    assert "note" in result
+
+
+def test_repl_quick_exit() -> None:
+    with patch("rich.prompt.Prompt.ask", side_effect=["exit"]):
+        repl.main()
+
+
+def test_repl_add_and_reflect(tmp_path: Path) -> None:
+    memory_file = tmp_path / "mem.txt"
+    with patch(
+        "rich.prompt.Prompt.ask", side_effect=["add hello", "reflect", "exit"]
+    ), patch("rich.console.Console.print") as mock_print:
+        repl.main(save=str(memory_file))
+        output = "".join(call.args[0] for call in mock_print.call_args_list)
+    assert "hello" in output
+    assert memory_file.exists()
+
+
+def test_repl_cli_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "labs/repl.py", "--help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "Eidos interactive REPL" in result.stdout


### PR DESCRIPTION
## Summary
- implement `Engine` for executing EidosCore operations
- add a Rich-powered REPL using `Engine`
- document the REPL in README
- update glossary and logbook
- mark completed items in TODO
- test Engine and REPL

## Testing
- `black --check --diff core agents labs tools tests`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c1726608323b0e85f97d74325de