### PR TITLE
Organize CLI using Command pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,27 @@ pytest
 
 The style tests verify formatting via `black` and linting via `flake8`.
 
-### Launching the Tutorial
+### Command-Line Interface
 
-`tutorial_app.py` showcases core concepts in an interactive session:
+All tools are accessible via a unified CLI:
 
 ```bash
-python labs/tutorial_app.py [--load PATH] [--save PATH]
+python tools/cli.py <command> [options]
 ```
 
-- `--load PATH` loads a memory file before starting.
-- `--save PATH` writes memories when exiting.
+Available commands include:
 
-Follow the prompts to add experiences, view memories, recurse, and exit.
+- `tutorial` – launch the interactive tutorial.
+- `glossary` – regenerate `knowledge/glossary_reference.md`.
+- `logbook` – append a cycle entry to the logbook.
+
+For example, to run the tutorial:
+
+```bash
+python tools/cli.py tutorial [--load PATH] [--save PATH]
+```
+
+Use `--help` after any command for further details.
 
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,19 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Command Pattern Template
+```python
+class Command:
+    """Base interface for CLI commands."""
+
+    name: str = "example"
+    help: str = "Explain what the command does"
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        pass
+
+    def run(self, args: argparse.Namespace) -> None:
+        raise NotImplementedError
+```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from tools import cli
+
+
+def test_parser_has_subcommands() -> None:
+    parser = cli.build_parser()
+    ns = parser.parse_args(["glossary"])
+    assert ns.command_cls is cli.GlossaryCommand
+
+    ns = parser.parse_args(["logbook", "msg"])
+    assert ns.command_cls is cli.LogbookCommand
+    assert ns.message == "msg"

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -12,7 +12,7 @@ def test_generate_glossary_cli(tmp_path: Path) -> None:
     backup = glossary_file.read_text() if glossary_file.exists() else ""
     try:
         result = subprocess.run(
-            [sys.executable, "tools/generate_glossary.py"],
+            [sys.executable, "tools/cli.py", "glossary"],
             capture_output=True,
             text=True,
         )

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -1,0 +1,113 @@
+"""Unified command-line interface for Eidos tools."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from labs import tutorial_app
+from tools import generate_glossary, logbook_entry
+
+
+class Command:
+    """Base interface for CLI commands."""
+
+    name: str = ""
+    help: str = ""
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        """Hook for command specific arguments."""
+
+    def run(self, args: argparse.Namespace) -> None:
+        """Execute the command."""
+        raise NotImplementedError
+
+    @classmethod
+    def build_parser(cls, subparsers: argparse._SubParsersAction) -> None:
+        """Register ``cls`` with ``subparsers``."""
+        parser = subparsers.add_parser(cls.name, help=cls.help)
+        cls.add_arguments(parser)
+        parser.set_defaults(command_cls=cls)
+
+
+class TutorialCommand(Command):
+    """Launch the interactive tutorial."""
+
+    name = "tutorial"
+    help = "Run the tutorial application"
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--load", help="Path to memory file to load", default=None)
+        parser.add_argument(
+            "--save", help="Path to save memories on exit", default=None
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        tutorial_app.main(load=args.load, save=args.save)
+
+
+class GlossaryCommand(Command):
+    """Generate the glossary reference."""
+
+    name = "glossary"
+    help = "Update glossary_reference.md"
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        """No custom arguments."""
+
+    def run(self, args: argparse.Namespace) -> None:
+        glossary = generate_glossary.scan_codebase()
+        generate_glossary.write_glossary(glossary)
+
+
+class LogbookCommand(Command):
+    """Append an entry to the logbook."""
+
+    name = "logbook"
+    help = "Add a new logbook entry"
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("message", help="Summary line for the logbook entry")
+        parser.add_argument("--next", dest="next_target", help="Optional next target")
+        parser.add_argument(
+            "--logbook",
+            type=Path,
+            default=logbook_entry.LOGBOOK_PATH,
+            help="Path to the logbook file",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        logbook_entry.append_entry(args.message, args.next_target, args.logbook)
+
+
+COMMANDS = [TutorialCommand, GlossaryCommand, LogbookCommand]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return a parser with all subcommands registered."""
+    parser = argparse.ArgumentParser(description="Eidos command-line interface")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for cmd in COMMANDS:
+        cmd.build_parser(subparsers)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the unified CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    command_cls: type[Command] = args.command_cls
+    command_cls().run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -6,7 +6,7 @@ import ast
 from pathlib import Path
 
 OUTPUT_PATH = Path("knowledge/glossary_reference.md")
-SOURCE_DIRS = ["core", "agents", "labs"]
+SOURCE_DIRS = ["core", "agents", "labs", "tools"]
 
 
 def extract_symbols(path: Path) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- implement a unified CLI (`tools/cli.py`) with Command pattern subcommands
- support tools directory in glossary generation
- document CLI usage in README
- add Command template documentation
- update tests for new CLI and add parser tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c17e4cc832383c113141d5d6829