### PR TITLE
Introduce FastAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,15 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
 
+### Running the API
+
+The FastAPI application exposes programmatic access to memory and agents.
+
+```bash
+uvicorn api.app:app
+```
+
+Visit `http://127.0.0.1:8000/docs` for interactive OpenAPI documentation.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+"""Expose the FastAPI application factory and default app instance."""
+
+from .app import create_app, app
+
+__all__ = ["create_app", "app"]

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,54 @@
+"""FastAPI application providing memory and agent endpoints."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from core.eidos_core import EidosCore
+from agents.utility_agent import UtilityAgent
+from agents.experiment_agent import ExperimentAgent
+
+
+def create_app() -> FastAPI:
+    """Return a configured FastAPI instance."""
+    app = FastAPI(title="Eidos API")
+
+    core = EidosCore()
+    utility = UtilityAgent()
+    experiment = ExperimentAgent()
+
+    class MemoryItem(BaseModel):
+        experience: str
+
+    class TaskItem(BaseModel):
+        task: str
+
+    class HypothesisItem(BaseModel):
+        hypothesis: str
+
+    @app.post("/memory")
+    async def add_memory(item: MemoryItem) -> dict[str, str]:
+        """Store an experience in memory."""
+        core.remember(item.experience)
+        return {"status": "stored"}
+
+    @app.get("/memory")
+    async def get_memory() -> list:
+        """Return all stored memories."""
+        return core.reflect()
+
+    @app.post("/agent/utility")
+    async def run_utility(task: TaskItem) -> dict[str, str]:
+        """Run a utility agent task."""
+        result = utility.perform_task(task.task)
+        return {"result": result}
+
+    @app.post("/agent/experiment")
+    async def run_experiment(data: HypothesisItem) -> dict[str, str]:
+        """Run an experiment agent with a hypothesis."""
+        result = experiment.run(data.hypothesis)
+        return {"result": result}
+
+    return app
+
+
+app = create_app()

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,11 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: API Exposure
+- Introduced a FastAPI application for programmatic memory and agent access.
+- Added endpoints for memory storage, querying, and agent execution.
+- Documented usage in README and expanded templates with an API pattern.
+- Extended tests to cover new API and style rules.
+
+**Next Target:** Enhance generated glossary entries and explore advanced API features.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,9 +1,5 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
@@ -11,6 +7,8 @@ Refer back to `templates.md` for code usage examples and to
 - UtilityAgent
 
 ## Functions
+- build_parser
+- create_app
 - load_memory
 - main
 - save_memory

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,15 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## FastAPI Application Template
+```python
+from fastapi import FastAPI
+
+
+def create_app() -> FastAPI:
+    """Return a configured FastAPI instance."""
+    app = FastAPI()
+    # register routes here
+    return app
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ rich
 pytest
 black
 flake8
+fastapi
+uvicorn
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from api.app import create_app
+
+
+def test_add_and_get_memory() -> None:
+    client = TestClient(create_app())
+    add = client.post("/memory", json={"experience": "hello"})
+    assert add.status_code == 200
+    get = client.get("/memory")
+    assert get.status_code == 200
+    assert "hello" in get.json()
+
+
+def test_agent_endpoints() -> None:
+    client = TestClient(create_app())
+    util = client.post("/agent/utility", json={"task": "clean"})
+    assert util.json()["result"] == "Performed clean"
+    exp = client.post("/agent/experiment", json={"hypothesis": "h1"})
+    assert exp.json()["result"] == "Experimenting with h1"
+
+
+def test_openapi_docs_available() -> None:
+    client = TestClient(create_app())
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    assert resp.json()["info"]["title"] == "Eidos API"

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -4,14 +4,25 @@ import subprocess
 def test_style():
     assert (
         subprocess.run(
-            ["black", "--check", "--diff", "core", "agents", "labs", "tools", "tests"],
+            [
+                "black",
+                "--check",
+                "--diff",
+                "core",
+                "agents",
+                "labs",
+                "tools",
+                "api",
+                "tests",
+            ],
             check=False,
         ).returncode
         == 0
     )
     assert (
         subprocess.run(
-            ["flake8", "core", "agents", "labs", "tools", "tests"], check=False
+            ["flake8", "core", "agents", "labs", "tools", "api", "tests"],
+            check=False,
         ).returncode
         == 0
     )

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -6,7 +6,7 @@ import ast
 from pathlib import Path
 
 OUTPUT_PATH = Path("knowledge/glossary_reference.md")
-SOURCE_DIRS = ["core", "agents", "labs"]
+SOURCE_DIRS = ["core", "agents", "labs", "api"]
 
 
 def extract_symbols(path: Path) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- create `api` package with a FastAPI app
- allow memory and agent interaction via HTTP
- document API usage in README
- add a FastAPI template in documentation
- include API routes in glossary generation
- add tests for the API and style rules
- update logbook with API cycle

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c187628832390a8bddb4bbdea19