### PR TITLE
Implement long-context adapter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E501,E402,W503
+ignore = E501,E402,W503,E203

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .long_context_adapter import LongContextAdapter
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "LongContextAdapter"]

--- a/core/long_context_adapter.py
+++ b/core/long_context_adapter.py
@@ -1,0 +1,32 @@
+"""Adapter to prepare long-context LLM interactions."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+from .meta_reflection import MetaReflection
+
+
+class LongContextAdapter:
+    """Summarize large memories for long-context LLM usage."""
+
+    def __init__(self, chunk_size: int = 20, max_summary_len: int = 200) -> None:
+        """Initialize the adapter with chunk and length limits."""
+        self.chunk_size = chunk_size
+        self.max_summary_len = max_summary_len
+        self.reflector = MetaReflection()
+
+    def summarize_chunk(self, memories: Iterable[Any]) -> str:
+        """Return a condensed summary for ``memories``."""
+        details = [self.reflector.analyze(m) for m in memories]
+        lines = [f"{d['type']}: {d['summary'] or d['repr']}" for d in details]
+        summary = "; ".join(lines)
+        return summary[: self.max_summary_len]
+
+    def summarize(self, memories: List[Any]) -> List[str]:
+        """Return summaries for batches of ``memories``."""
+        summaries: List[str] = []
+        for i in range(0, len(memories), self.chunk_size):
+            chunk = memories[i : i + self.chunk_size]
+            summaries.append(self.summarize_chunk(chunk))
+        return summaries

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,8 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: 2025-06-13 13:59 UTC
+- Added long context adapter and templates
+
+**Next Target:** Extend adapter tests

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,14 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
+- LongContextAdapter
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,17 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Adapter Template
+```python
+class AdapterName:
+    """Handle transformation between components."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or {}
+
+    def adapt(self, data: object) -> object:
+        """Convert ``data`` to the desired format."""
+        # Adaptation logic goes here
+        return data
+```

--- a/tests/test_long_context_adapter.py
+++ b/tests/test_long_context_adapter.py
@@ -1,0 +1,15 @@
+from core.long_context_adapter import LongContextAdapter
+
+
+def test_summarize_batches() -> None:
+    adapter = LongContextAdapter(chunk_size=2)
+    data = ["a", "b", "c"]
+    summaries = adapter.summarize(data)
+    assert len(summaries) == 2
+    assert all(isinstance(s, str) for s in summaries)
+
+
+def test_summary_contains_preview() -> None:
+    adapter = LongContextAdapter(chunk_size=1)
+    summaries = adapter.summarize(["hello world"])
+    assert "chars preview" in summaries[0]


### PR DESCRIPTION
## Summary
- create `LongContextAdapter` to condense large memories
- export new adapter from `core` package
- add adapter test cases
- update documentation templates with an Adapter snippet
- record new development cycle in the logbook
- regenerate glossary
- relax flake8 rules for Black compatibility

## Testing
- `black core agents labs tools tests knowledge -q`
- `flake8 core agents labs tools tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684c2c1d0588832392368a06e9e8772f