### PR TITLE
Add LLM-driven improvement agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run wild. Evolve forever.
 
 ## Structure
 - **core/**: central logic of the system
-- **agents/**: specialized actors for experiments and utilities
+- **agents/**: specialized actors for experiments, utilities, and improvement proposals
 - **knowledge/**: evolving documentation and design patterns
 - **labs/**: sandbox for rapid prototyping
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -2,5 +2,6 @@
 
 from .utility_agent import UtilityAgent
 from .experiment_agent import ExperimentAgent
+from .improvement_agent import ImprovementAgent
 
-__all__ = ["UtilityAgent", "ExperimentAgent"]
+__all__ = ["UtilityAgent", "ExperimentAgent", "ImprovementAgent"]

--- a/agents/improvement_agent.py
+++ b/agents/improvement_agent.py
@@ -1,0 +1,25 @@
+"""Agent that proposes codebase improvements using an LLM."""
+
+from __future__ import annotations
+
+from typing import List
+
+from core.llm_adapter import LLMAdapter
+
+
+class ImprovementAgent:
+    """Use :class:`LLMAdapter` to generate and store suggestions."""
+
+    def __init__(self, llm: LLMAdapter | None = None) -> None:
+        self.llm = llm or LLMAdapter()
+        self.suggestions: List[str] = []
+
+    def propose(self, text: str) -> str:
+        """Return an improvement suggestion for ``text`` and record it."""
+        suggestion = self.llm.query(text)
+        self.suggestions.append(suggestion)
+        return suggestion
+
+    def history(self) -> List[str]:
+        """Return a copy of stored suggestions."""
+        return list(self.suggestions)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .llm_adapter import LLMAdapter
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "LLMAdapter"]

--- a/core/llm_adapter.py
+++ b/core/llm_adapter.py
@@ -1,0 +1,11 @@
+"""Simplified adapter for querying a large language model."""
+
+from __future__ import annotations
+
+
+class LLMAdapter:
+    """Provide a lightweight interface to an LLM service."""
+
+    def query(self, prompt: str) -> str:
+        """Return a placeholder response for ``prompt``."""
+        return f"Suggestion: {prompt}"

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -14,6 +14,7 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 ## Agents
 - [ ] Explore new utility agents.
 - [ ] Expand agent features and tests.
+- [ ] Develop ImprovementAgent using LLMAdapter.
 
 ## Tools
 - [ ] Build interactive CLI utilities for rapid experimentation.

--- a/knowledge/emergent_insights.md
+++ b/knowledge/emergent_insights.md
@@ -6,3 +6,4 @@ defined in `glossary_reference.md`.
 
 * Insight 1: Memory recursion can transform raw data into knowledge.
 * Insight 2: Templates enforce consistent design, enabling scalability.
+* Insight 3: LLM-driven agents can surface novel improvements automatically.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,15 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
+- ImprovementAgent
+- LLMAdapter
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.utility_agent import UtilityAgent
 from agents.experiment_agent import ExperimentAgent
+from agents.improvement_agent import ImprovementAgent
 
 
 def test_utility_agent_perform_task():
@@ -29,3 +30,10 @@ def test_experiment_agent_run_series():
     agent = ExperimentAgent()
     results = agent.run_series(["h1", "h2"])
     assert results == ["Experimenting with h1", "Experimenting with h2"]
+
+
+def test_improvement_agent_propose():
+    agent = ImprovementAgent()
+    output = agent.propose("refactor module")
+    assert "refactor module" in output
+    assert agent.history() == [output]

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,7 @@
+from core.llm_adapter import LLMAdapter
+
+
+def test_query_echoes_prompt():
+    adapter = LLMAdapter()
+    result = adapter.query("hello")
+    assert result == "Suggestion: hello"


### PR DESCRIPTION
## Summary
- create a lightweight `LLMAdapter`
- implement `ImprovementAgent` to propose and store suggestions
- expose new classes in package exports
- document new functionality in README and knowledge docs
- update glossary via generation script
- add unit tests for the adapter and agent

## Testing
- `flake8 core agents tests tools`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c1d171c83238e6ed2295a9c590b