### PR TITLE
Add recursive memory summarization utilities

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .memory_summary import MemorySummarizer
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "MemorySummarizer"]

--- a/core/memory_summary.py
+++ b/core/memory_summary.py
@@ -1,0 +1,27 @@
+"""Recursive summarization utilities for memory chunks."""
+
+from __future__ import annotations
+
+from typing import Sequence, Any, List
+
+from .meta_reflection import MetaReflection
+
+
+class MemorySummarizer:
+    """Condense large memories for LLM consumption."""
+
+    def __init__(self, chunk_size: int = 5) -> None:
+        self.chunk_size = chunk_size
+        self.reflector = MetaReflection()
+
+    def summarize(self, items: Sequence[Any]) -> str:
+        """Return a recursive summary string for ``items``."""
+        if len(items) <= self.chunk_size:
+            analysis = self.reflector.analyze(list(items))
+            return analysis.get("summary") or analysis.get("repr")
+        chunks: List[Sequence[Any]] = [
+            items[i : i + self.chunk_size]  # noqa: E203
+            for i in range(0, len(items), self.chunk_size)
+        ]
+        chunk_summaries = [self.summarize(chunk) for chunk in chunks]
+        return self.summarize(chunk_summaries)

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,10 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Memory Summaries
+- Created `MemorySummarizer` for recursive chunk summarization
+- Added template and pattern docs for summaries
+- Updated glossary to include new class
+
+**Next Target:** Integrate summarizer into tutorial and agents

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,14 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
+- MemorySummarizer
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/knowledge/recursive_patterns.md
+++ b/knowledge/recursive_patterns.md
@@ -12,3 +12,7 @@ documentation references are organized in the `glossary_reference.md`.
 ### Combined Cycle Pattern
 Use `process_cycle` to store an experience and immediately recurse,
 appending reflective insights in a single step.
+
+## Recursive Summary Pattern
+Condense large memory collections by chunking and summarizing
+with `MemorySummarizer` as shown in the ``Recursive Summary Template``.

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,14 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Recursive Summary Template
+```python
+def recursive_summary(items: list[Any], chunk_size: int = 10) -> str:
+    """Condense ``items`` into a short summary."""
+    if len(items) <= chunk_size:
+        return "; ".join(map(str, items))
+    chunks = [items[i : i + chunk_size] for i in range(0, len(items), chunk_size)]
+    summaries = [recursive_summary(chunk, chunk_size) for chunk in chunks]
+    return recursive_summary(summaries, chunk_size)
+```

--- a/tests/test_memory_summary.py
+++ b/tests/test_memory_summary.py
@@ -1,0 +1,9 @@
+from core.memory_summary import MemorySummarizer
+
+
+def test_recursive_summary():
+    data = list(range(10))
+    summarizer = MemorySummarizer(chunk_size=3)
+    summary = summarizer.summarize(data)
+    assert isinstance(summary, str)
+    assert "items" in summary


### PR DESCRIPTION
## Summary
- implement `MemorySummarizer` to condense large memory chunks
- document a recursive summary template and pattern
- extend glossary and logbook entries
- add tests for summarizer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684c2c1ebb248323b4b4984308c80706