### PR TITLE
Add security utilities for LLM interactions

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,11 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .security import RateLimiter, filter_sensitive_content
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = [
+    "EidosCore",
+    "MetaReflection",
+    "RateLimiter",
+    "filter_sensitive_content",
+]

--- a/core/security.py
+++ b/core/security.py
@@ -1,0 +1,45 @@
+"""Protection utilities for LLM interactions."""
+
+from __future__ import annotations
+
+from collections import deque
+from time import monotonic
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class RateLimiter:
+    """Limit the number of allowed operations within a time window."""
+
+    def __init__(self, max_calls: int, period: float) -> None:
+        self.max_calls = max_calls
+        self.period = period
+        self._timestamps: deque[float] = deque()
+
+    def allow(self) -> bool:
+        """Return ``True`` if another call is permitted."""
+        now = monotonic()
+        while self._timestamps and now - self._timestamps[0] > self.period:
+            self._timestamps.popleft()
+        if len(self._timestamps) < self.max_calls:
+            self._timestamps.append(now)
+            return True
+        return False
+
+    def wrap(self, func: Callable[..., T]) -> Callable[..., T]:
+        """Return ``func`` wrapped with rate limiting."""
+
+        def wrapped(*args: object, **kwargs: object) -> T:
+            if not self.allow():
+                raise RuntimeError("Rate limit exceeded")
+            return func(*args, **kwargs)
+
+        return wrapped
+
+
+def filter_sensitive_content(text: str, secrets: list[str]) -> str:
+    """Return ``text`` with each secret replaced by ``"[REDACTED]"``."""
+    for secret in secrets:
+        text = text.replace(secret, "[REDACTED]")
+    return text

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -10,3 +10,4 @@ Documentation includes:
 - `TODO.md` – prioritized list of upcoming work across all domains.
 
 Every document can reference the others. Templates are showcased in `templates.md` and applied through the patterns described in `recursive_patterns.md`. Terminology is normalized via `glossary_reference.md` so explanations remain consistent.
+New documents outline LLM protection strategies via rate limiting and content filtering.

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,10 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Security Utilities
+- Implemented `RateLimiter` and `filter_sensitive_content` in `core.security`.
+- Documented the LLM Protection pattern and updated insights.
+- Generated an updated glossary.
+
+**Next Target:** Integrate safeguards into agent workflows

--- a/knowledge/emergent_insights.md
+++ b/knowledge/emergent_insights.md
@@ -6,3 +6,4 @@ defined in `glossary_reference.md`.
 
 * Insight 1: Memory recursion can transform raw data into knowledge.
 * Insight 2: Templates enforce consistent design, enabling scalability.
+* Insight 3: Rate limiting and filtering safeguard LLM interactions.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,16 +1,15 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
 - MetaReflection
+- RateLimiter
 - UtilityAgent
 
 ## Functions
+- build_parser
+- filter_sensitive_content
 - load_memory
 - main
 - save_memory
@@ -18,3 +17,4 @@ Refer back to `templates.md` for code usage examples and to
 ## Constants
 - MANIFESTO_PROMPT
 - ROOT
+- T

--- a/knowledge/recursive_patterns.md
+++ b/knowledge/recursive_patterns.md
@@ -12,3 +12,8 @@ documentation references are organized in the `glossary_reference.md`.
 ### Combined Cycle Pattern
 Use `process_cycle` to store an experience and immediately recurse,
 appending reflective insights in a single step.
+
+## LLM Protection Pattern
+1. Limit request frequency with `RateLimiter`.
+2. Scrub sensitive content via `filter_sensitive_content`.
+3. Wrap LLM calls using both mechanisms.

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.security import RateLimiter, filter_sensitive_content
+
+
+def test_filter_sensitive_content() -> None:
+    text = "token=SECRET"
+    result = filter_sensitive_content(text, ["SECRET"])
+    assert result == "token=[REDACTED]"
+
+
+def test_rate_limiter_blocks(monkeypatch) -> None:
+    times = iter([0.0, 0.1, 0.2])
+    monkeypatch.setattr("core.security.monotonic", lambda: next(times))
+    limiter = RateLimiter(2, 1.0)
+    assert limiter.allow()
+    assert limiter.allow()
+    assert not limiter.allow()


### PR DESCRIPTION
## Summary
- add `RateLimiter` and `filter_sensitive_content` utilities
- expose new utilities in core package
- document the new LLM Protection pattern and insights
- update glossary and logbook
- test new security utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c1fc0948323810f23775e61e16c