### PR TITLE
Increase test coverage

### DIFF
--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,12 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Integration Test Template
+```python
+def test_integration(tmp_path: Path) -> None:
+    """Exercise multiple modules working together."""
+    result = cli_entrypoint("--output", tmp_path / "out.txt")
+    assert (tmp_path / "out.txt").exists()
+    assert "Success" in result
+```

--- a/tests/test_logbook_utils.py
+++ b/tests/test_logbook_utils.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from tools import logbook_entry
+
+
+def test_read_logbook_missing(tmp_path: Path) -> None:
+    path = tmp_path / "none.md"
+    text = logbook_entry.read_logbook(path)
+    assert text == "# Eidos Logbook\n"
+
+
+def test_next_cycle_number_gaps() -> None:
+    text = "# Eidos Logbook\n\n## Cycle 1:\n- a\n\n## Cycle 3:\n- c\n"
+    assert logbook_entry.next_cycle_number(text) == 4
+
+
+def test_format_entry_without_next(monkeypatch) -> None:
+    fixed_time = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_time
+
+    monkeypatch.setattr(logbook_entry, "datetime", FixedDatetime)
+    entry = logbook_entry.format_entry(5, "info")
+    assert "## Cycle 5: 2024-01-01 00:00 UTC" in entry
+    assert entry.endswith("\n")
+
+
+def test_append_entry_creates_file(tmp_path: Path, monkeypatch) -> None:
+    fixed_time = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_time
+
+    monkeypatch.setattr(logbook_entry, "datetime", FixedDatetime)
+    path = tmp_path / "log.md"
+    logbook_entry.append_entry("first", None, path)
+    assert path.exists()
+    content = path.read_text()
+    assert "## Cycle 1:" in content
+    assert "- first" in content

--- a/tests/test_meta_reflection.py
+++ b/tests/test_meta_reflection.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.meta_reflection import MetaReflection
+
+
+def test_analyze_list_summary() -> None:
+    ref = MetaReflection()
+    result = ref.analyze([1, 2, 3])
+    assert result["summary"] == "contains 3 items"
+    assert result["type"] == "list"
+
+
+def test_analyze_dict_summary() -> None:
+    ref = MetaReflection()
+    result = ref.analyze({"a": 1, "b": 2})
+    assert result["summary"] == "mapping with 2 keys"
+    assert result["type"] == "dict"
+
+
+def test_analyze_long_string() -> None:
+    ref = MetaReflection()
+    data = "x" * 30
+    result = ref.analyze(data)
+    assert result["summary"].startswith("20 chars preview:")
+    assert result["length"] == len(data)

--- a/tests/test_tutorial_app_extra.py
+++ b/tests/test_tutorial_app_extra.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+from pathlib import Path
+
+from labs import tutorial_app
+
+
+def test_load_memory_no_file(tmp_path: Path) -> None:
+    core = tutorial_app.EidosCore()
+    file_path = tmp_path / "missing.txt"
+    console = tutorial_app.Console(record=True)
+    tutorial_app.load_memory(core, file_path, console)
+    assert "No memory file" in console.export_text()
+
+
+def test_load_memory_failure(tmp_path: Path) -> None:
+    core = tutorial_app.EidosCore()
+    file_path = tmp_path / "err.txt"
+    console = tutorial_app.Console(record=True)
+    with patch.object(Path, "exists", side_effect=OSError("boom")):
+        tutorial_app.load_memory(core, file_path, console)
+    assert "Failed to load memory" in console.export_text()
+
+
+def test_save_memory_failure(tmp_path: Path) -> None:
+    core = tutorial_app.EidosCore()
+    core.memory.append("data")
+    file_path = tmp_path / "err.txt"
+    console = tutorial_app.Console(record=True)
+    with patch.object(Path, "write_text", side_effect=OSError("boom")):
+        tutorial_app.save_memory(core, file_path, console)
+    assert "Failed to save memory" in console.export_text()


### PR DESCRIPTION
## Summary
- add integration test template
- extend unit test coverage for meta reflection
- cover tutorial failure paths
- add logbook entry tests

## Testing
- `python3 -m coverage run -m pytest -q`
- `python3 -m coverage report`

------
https://chatgpt.com/codex/tasks/task_b_684c2c241bbc8323a2de4c346ed5cef0