### PR TITLE
Add fuzz test harness

### DIFF
--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,10 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Resilience Testing
+- Introduced Atheris-based fuzz tests to stress `EidosCore` input handling
+- Added a fuzz test template for future modules
+- Recorded a new insight on the value of fuzzing in `emergent_insights.md`
+
+**Next Target:** Extend fuzzing to CLI tools and expand glossary automation

--- a/knowledge/emergent_insights.md
+++ b/knowledge/emergent_insights.md
@@ -6,3 +6,4 @@ defined in `glossary_reference.md`.
 
 * Insight 1: Memory recursion can transform raw data into knowledge.
 * Insight 2: Templates enforce consistent design, enabling scalability.
+* Insight 3: Fuzz testing guards against unhandled edge cases in the engine.

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,25 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Fuzz Test Template
+```python
+import sys
+import pytest
+
+atheris = pytest.importorskip("atheris")
+atheris.instrument_all()
+
+
+def fuzz_one_input(data: bytes) -> None:
+    """Handle fuzzed ``data`` for the target function."""
+    # target_function consumes arbitrary input
+    target_function(data)
+
+
+def test_fuzz() -> None:
+    """Run Atheris fuzzing with a limited number of iterations."""
+    atheris.Setup(sys.argv + ["-runs=10"], fuzz_one_input)
+    with pytest.raises(SystemExit):
+        atheris.Fuzz()
+```

--- a/tests/test_fuzz_eidos_core.py
+++ b/tests/test_fuzz_eidos_core.py
@@ -1,0 +1,29 @@
+import sys
+import pytest
+
+atheris = pytest.importorskip("atheris")
+atheris.instrument_all()
+
+from core.eidos_core import EidosCore
+
+
+def _fuzz_input(data: bytes) -> None:
+    """Feed fuzzed bytes into :class:`EidosCore`."""
+    core = EidosCore()
+    fdp = atheris.FuzzedDataProvider(data)
+    if fdp.ConsumeBool():
+        value = fdp.ConsumeUnicodeNoSurrogates(64)
+    else:
+        value = {fdp.ConsumeUnicodeNoSurrogates(5): fdp.ConsumeUnicodeNoSurrogates(5)}
+    try:
+        core.process_cycle(value)
+    except Exception:
+        pass
+
+
+def test_fuzz_engine() -> None:
+    """Run a short fuzzing session to stress input handling."""
+    atheris.Setup(sys.argv + ["-runs=50"], _fuzz_input)
+    with pytest.raises(SystemExit) as exc:
+        atheris.Fuzz()
+    assert exc.value.code == 0


### PR DESCRIPTION
## Summary
- integrate an Atheris based fuzz test for EidosCore
- template for fuzz testing in the knowledge base
- log latest development cycle and new insight about fuzzing

## Testing
- `black --check --diff core agents labs tools tests`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c2582748323a3cd5af0a9a7018c