### PR TITLE
Add mutation testing with mutmut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+.mutmut-cache/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ pytest
 
 The style tests verify formatting via `black` and linting via `flake8`.
 
+### Mutation Testing
+
+Mutation testing checks how well the suite detects code changes. Execute it via
+the provided CLI:
+
+```bash
+python tools/mutation_test.py
+```
+
 ### Launching the Tutorial
 
 `tutorial_app.py` showcases core concepts in an interactive session:

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -28,3 +28,4 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 - [ ] Create comprehensive tests for core and agents.
 - [ ] Enforce style checks with black and flake8.
 - [ ] Expand coverage for CLI tools and reflection logic.
+- [ ] Integrate mutation testing with mutmut.

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,8 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: 2025-06-13 13:51 UTC
+- Added mutation testing CLI and docs
+
+**Next Target:** Refine mutation test coverage

--- a/knowledge/emergent_insights.md
+++ b/knowledge/emergent_insights.md
@@ -6,3 +6,4 @@ defined in `glossary_reference.md`.
 
 * Insight 1: Memory recursion can transform raw data into knowledge.
 * Insight 2: Templates enforce consistent design, enabling scalability.
+* Insight 3: Mutation testing highlights fragile assumptions in the suite.

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,13 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Mutation Test Script Template
+```python
+import subprocess
+
+
+def run_mutation_tests() -> int:
+    """Execute mutmut and return its exit code."""
+    return subprocess.call(["mutmut", "run"])
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ rich
 pytest
 black
 flake8
+mutmut

--- a/tests/test_mutation_cli.py
+++ b/tests/test_mutation_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+
+
+def test_mutation_cli_help() -> None:
+    """Ensure the mutation testing CLI is accessible."""
+    result = subprocess.run(
+        [sys.executable, "tools/mutation_test.py", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "mutation tests" in result.stdout

--- a/tools/mutation_test.py
+++ b/tools/mutation_test.py
@@ -1,0 +1,44 @@
+"""CLI wrapper for running mutmut mutation tests."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+
+from rich.console import Console
+
+
+def run_mutmut(no_cache: bool = False) -> int:
+    """Run mutmut and return its exit code."""
+    cmd = ["mutmut", "run"]
+    if no_cache:
+        cmd.append("--no-cache")
+    return subprocess.call(cmd)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return an argument parser for the CLI."""
+    parser = argparse.ArgumentParser(description="Execute mutation tests with mutmut")
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable cache for a full mutation run",
+    )
+    return parser
+
+
+def main() -> None:
+    """Entry point for mutation test execution."""
+    console = Console()
+    parser = build_parser()
+    args = parser.parse_args()
+    code = run_mutmut(no_cache=args.no_cache)
+    if code == 0:
+        console.print("All mutations survived.", style="green")
+    else:
+        console.print("Mutation test failures detected.", style="red")
+    raise SystemExit(code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce a CLI wrapper for running mutation tests via mutmut
- add new mutation test script template
- document mutation testing in README and TODO
- log the development cycle and insight
- ignore mutmut cache and require mutmut in requirements
- add simple CLI test for mutation testing tool

## Testing
- `pip install rich`
- `pip install flake8 black`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c274f1c8323ad927494146f0694