### PR TITLE
Add CI workflow and Docker support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install mypy pytest-cov mutmut
+      - name: Lint
+        run: |
+          black --check core agents labs tools tests
+          flake8 core agents labs tools tests
+      - name: Type Check
+        run: mypy core agents labs tools
+      - name: Test with coverage
+        run: pytest --cov=.
+      - name: Mutation tests
+        run: mutmut run --paths-to-mutate core --runner pytest --tests-dir tests --use-coverage
+      - name: Docker build
+        run: docker build -t eidos-brain .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["pytest"]

--- a/README.md
+++ b/README.md
@@ -57,5 +57,15 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
 
+## Continuous Integration
+The project includes a GitHub Actions workflow that verifies code quality and
+builds a Docker image. It performs:
+
+1. Linting with `black` and `flake8`.
+2. Static type checks with `mypy`.
+3. Unit tests with coverage reporting.
+4. Mutation tests via `mutmut`.
+5. A Docker build to ensure the container configuration is valid.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -5,6 +5,7 @@ Documentation includes:
 - `eidos_logbook.md` – chronological record of each development cycle.
 - `recursive_patterns.md` – catalog of recurring design techniques used throughout the project.
 - `templates.md` – reusable code and documentation templates that ensure consistent style.
+- `templates.md` also includes a workflow template for the CI pipeline.
 - `glossary_reference.md` – generated glossary of important classes, functions, and constants.
 - `emergent_insights.md` – distilled lessons and observations from recursive experimentation.
 - `TODO.md` – prioritized list of upcoming work across all domains.

--- a/knowledge/TODO.md
+++ b/knowledge/TODO.md
@@ -28,3 +28,4 @@ This document tracks upcoming tasks across the project. Mark items complete as p
 - [ ] Create comprehensive tests for core and agents.
 - [ ] Enforce style checks with black and flake8.
 - [ ] Expand coverage for CLI tools and reflection logic.
+- [ ] Integrate CI pipeline with linting, type checks, coverage, mutation tests, and Docker build.

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,11 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: CI Integration
+- Added a Dockerfile and CI workflow executing lint, type checks, coverage tests,
+  mutation tests, and Docker build.
+- Documented the workflow in README and provided a new template.
+- Updated TODO with a task to integrate the pipeline.
+
+**Next Target:** Explore release automation and enforce coverage thresholds.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,9 +1,5 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
@@ -11,6 +7,7 @@ Refer back to `templates.md` for code usage examples and to
 - UtilityAgent
 
 ## Functions
+- build_parser
 - load_memory
 - main
 - save_memory

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,27 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Workflow Template
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Lint
+        run: black --check core
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ rich
 pytest
 black
 flake8
+mypy
+pytest-cov
+mutmut


### PR DESCRIPTION
## Summary
- add Dockerfile for container builds
- create CI workflow executing lint, type checks, coverage tests, mutation tests, and docker build
- document CI pipeline in README and templates
- update TODO and logbook
- refresh glossary

## Testing
- `pytest -q`
- `black --check core agents labs tools tests`
- `flake8 core agents labs tools tests`


------
https://chatgpt.com/codex/tasks/task_b_684c2c27e26c8323a2b500dfb6c10e69