### PR TITLE
Add MkDocs documentation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,17 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
 
+### Building Documentation
+
+MkDocs with the Material theme and `mkdocstrings` renders the API
+documentation located in the `docs/` directory. Use the following commands:
+
+```bash
+mkdocs serve  # start a local preview
+mkdocs build  # generate the static site in the 'site/' folder
+```
+
+The resulting pages provide a browsable reference for all modules.
+
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Eidos-Brain Documentation
+
+Welcome to the internal documentation site for **Eidos-Brain**. This site is built
+with [MkDocs](https://www.mkdocs.org/) using the
+[Material theme](https://squidfunk.github.io/mkdocs-material/) and
+[mkdocstrings](https://mkdocstrings.github.io/) to automatically generate API
+references.
+
+The project overview in [README.md](../README.md) provides a quick introduction.
+For design patterns and templates see the files within the
+[`knowledge/`](../knowledge/README.md) directory.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,9 @@
+# API Reference
+
+::: core.eidos_core
+
+::: core.meta_reflection
+
+::: agents.utility_agent
+
+::: agents.experiment_agent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: Eidos-Brain
+theme:
+  name: material
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: ["."]
+nav:
+  - Home: index.md
+  - Reference: reference.md
+markdown_extensions:
+  - admonition
+  - codehilite
+  - toc:
+      permalink: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ rich
 pytest
 black
 flake8
+mkdocs
+mkdocs-material
+mkdocstrings[python]


### PR DESCRIPTION
## Summary
- set up MkDocs using the Material theme and mkdocstrings
- create initial documentation pages
- document how to build the docs
- add required packages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c289d6083239291d0f92323196b