### PR TITLE
Enhance glossary generator with definitions

### DIFF
--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -5,7 +5,7 @@ Documentation includes:
 - `eidos_logbook.md` – chronological record of each development cycle.
 - `recursive_patterns.md` – catalog of recurring design techniques used throughout the project.
 - `templates.md` – reusable code and documentation templates that ensure consistent style.
-- `glossary_reference.md` – generated glossary of important classes, functions, and constants.
+- `glossary_reference.md` – generated glossary of important classes, functions, and constants with emoji icons and definitions.
 - `emergent_insights.md` – distilled lessons and observations from recursive experimentation.
 - `TODO.md` – prioritized list of upcoming work across all domains.
 

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,20 +1,17 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
-- EidosCore
-- ExperimentAgent
-- MetaReflection
-- UtilityAgent
+- 🏷️ **EidosCore** - Manage memory and recursive processing using :class:`MetaReflection`.
+- 🏷️ **ExperimentAgent** - Handles experimental cycles and evaluations.
+- 🏷️ **MetaReflection** - Provide data analysis and summarization utilities.
+- 🏷️ **UtilityAgent** - Provides supporting functions for the system.
 
 ## Functions
-- load_memory
-- main
-- save_memory
+- ⚙️ **build_parser** - Return an argument parser for the CLI.
+- ⚙️ **load_memory** - Load memories from ``path`` if it exists.
+- ⚙️ **main** - Run the tutorial application.
+- ⚙️ **save_memory** - Persist memories to ``path``.
 
 ## Constants
-- MANIFESTO_PROMPT
-- ROOT
+- 🔖 **MANIFESTO_PROMPT** - You are Eidos—an autonomous, recursively self-improving digital being.
+- 🔖 **ROOT** - Constant defined in tutorial_app.py

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -20,5 +20,7 @@ def test_generate_glossary_cli(tmp_path: Path) -> None:
         content = glossary_file.read_text()
         assert "EidosCore" in content
         assert "UtilityAgent" in content
+        assert "\u2699\ufe0f" in content or "\U0001f3f7\ufe0f" in content
+        assert "Manage memory" in content
     finally:
         glossary_file.write_text(backup)

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -1,49 +1,90 @@
-"""Generate a glossary of symbols within the codebase."""
+"""Generate a glossary of symbols within the codebase with descriptions."""
 
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 OUTPUT_PATH = Path("knowledge/glossary_reference.md")
 SOURCE_DIRS = ["core", "agents", "labs"]
 
+ICON_MAP = {
+    "class": "\U0001f3f7\ufe0f",
+    "function": "\u2699\ufe0f",
+    "constant": "\U0001f516",
+}
 
-def extract_symbols(path: Path) -> list[tuple[str, str]]:
-    """Return a list of (symbol, kind) pairs defined in a file."""
-    symbols: list[tuple[str, str]] = []
+
+@dataclass
+class GlossaryEntry:
+    """Container for glossary information."""
+
+    name: str
+    description: str
+
+
+def extract_symbols(path: Path) -> list[tuple[str, str, str]]:
+    """Return a list of ``(symbol, kind, description)`` defined in ``path``."""
+
+    symbols: list[tuple[str, str, str]] = []
     tree = ast.parse(path.read_text())
     for node in tree.body:
         if isinstance(node, ast.ClassDef):
-            symbols.append((node.name, "class"))
+            doc = ast.get_docstring(node) or ""
+            desc = doc.splitlines()[0] if doc else ""
+            symbols.append((node.name, "class", desc))
         elif isinstance(node, ast.FunctionDef):
-            symbols.append((node.name, "function"))
+            doc = ast.get_docstring(node) or ""
+            desc = doc.splitlines()[0] if doc else ""
+            symbols.append((node.name, "function", desc))
         elif isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id.isupper():
-                    symbols.append((target.id, "constant"))
+                    desc = ""
+                    if isinstance(node.value, ast.Constant) and isinstance(
+                        node.value.value, str
+                    ):
+                        desc = node.value.value.splitlines()[0]
+                    if not desc:
+                        desc = f"Constant defined in {path.name}"
+                    symbols.append((target.id, "constant", desc))
     return symbols
 
 
-def scan_codebase() -> dict[str, list[str]]:
+def scan_codebase() -> dict[str, list[GlossaryEntry]]:
     """Scan source directories for symbols grouped by kind."""
-    glossary: dict[str, list[str]] = {"class": [], "function": [], "constant": []}
+
+    glossary: dict[str, list[GlossaryEntry]] = {
+        "class": [],
+        "function": [],
+        "constant": [],
+    }
     for directory in SOURCE_DIRS:
         for path in Path(directory).glob("*.py"):
-            for name, kind in extract_symbols(path):
-                glossary[kind].append(name)
+            for name, kind, desc in extract_symbols(path):
+                glossary[kind].append(GlossaryEntry(name, desc))
     return glossary
 
 
-def write_glossary(glossary: dict[str, list[str]]) -> None:
-    """Write collected symbols to the glossary file."""
-    plural_map = {"class": "Classes", "function": "Functions", "constant": "Constants"}
+def write_glossary(glossary: dict[str, list[GlossaryEntry]]) -> None:
+    """Write collected symbols and descriptions to ``OUTPUT_PATH``."""
+
+    plural_map = {
+        "class": "Classes",
+        "function": "Functions",
+        "constant": "Constants",
+    }
     lines = ["# Glossary Reference", ""]
-    for kind, names in glossary.items():
+    for kind, entries in glossary.items():
         header = plural_map.get(kind, kind.title() + "s")
         lines.append(f"## {header}")
-        for name in sorted(set(names)):
-            lines.append(f"- {name}")
+        icon = ICON_MAP.get(kind, "")
+        for entry in sorted(entries, key=lambda e: e.name):
+            line = f"- {icon} **{entry.name}**"
+            if entry.description:
+                line += f" - {entry.description}"
+            lines.append(line)
         lines.append("")
     OUTPUT_PATH.write_text("\n".join(lines))
 


### PR DESCRIPTION
## Summary
- generate glossary with icons and short descriptions
- document glossary improvements in knowledge README
- test icons and definitions in glossary output

## Testing
- `pip install -r requirements.txt`
- `black core agents labs tools tests --quiet`
- `flake8 core agents labs tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c29e1348323b8105a98b0bcf909