### PR TITLE
Add docs notebook with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,12 @@ Follow the prompts to add experiences, view memories, recurse, and exit.
 
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>
+
+### Building Documentation
+
+The `docs/core_usage.ipynb` notebook is executed during documentation builds to
+validate code examples. You can run it manually with:
+
+```bash
+jupyter nbconvert --to html --execute docs/core_usage.ipynb
+```

--- a/docs/core_usage.ipynb
+++ b/docs/core_usage.ipynb
@@ -1,0 +1,50 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Core Usage Example\n",
+        "This notebook demonstrates how to use `EidosCore`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import sys, pathlib\n",
+        "ROOT = pathlib.Path(\"..\").resolve()\n",
+        "if str(ROOT) not in sys.path:\n",
+        "    sys.path.insert(0, str(ROOT))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from core.eidos_core import EidosCore\n",
+        "core = EidosCore()\n",
+        "core.remember('hello')\n",
+        "core.recurse()\n",
+        "core.reflect()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,16 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## Notebook Template
+```python
+# cell 1 - markdown
+# """Title and description"""
+
+# cell 2 - code
+from core.eidos_core import EidosCore
+core = EidosCore()
+core.remember("example")
+core.recurse()
+core.reflect()
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ rich
 pytest
 black
 flake8
+
+jupyter

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_core_usage_notebook_executes(tmp_path: Path) -> None:
+    """Run the core usage notebook to ensure it executes without error."""
+    notebook = Path("docs/core_usage.ipynb")
+    assert notebook.exists()
+    output = tmp_path / "out.ipynb"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jupyter",
+            "nbconvert",
+            "--to",
+            "html",
+            "--execute",
+            "--output",
+            output,
+            notebook,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- document how to build docs via Jupyter notebook
- provide notebook template
- require Jupyter for documentation builds
- add example notebook executed during docs build
- test notebook execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c2bc2f88323abc6a3c6eaf9ea03