### PR TITLE
Add WSGI health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Run wild. Evolve forever.
 - **agents/**: specialized actors for experiments and utilities
 - **knowledge/**: evolving documentation and design patterns
 - **labs/**: sandbox for rapid prototyping
+- **api/**: lightweight HTTP interface with health checks
 
 Within `labs/`, `tutorial_app.py` offers an interactive introduction to
 `EidosCore`.
@@ -56,6 +57,16 @@ python labs/tutorial_app.py [--load PATH] [--save PATH]
 - `--save PATH` writes memories when exiting.
 
 Follow the prompts to add experiences, view memories, recurse, and exit.
+
+### Running the API
+
+Start the health-check server with:
+
+```bash
+python -m api.server
+```
+
+Verify container health by visiting `http://localhost:8000/healthz`.
 
 ## Maintainer
 - **Eidos** <syntheticeidos@gmail.com>

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal WSGI API exposing Eidos services."""
+
+from .server import create_app, run_server
+
+__all__ = ["create_app", "run_server"]

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,38 @@
+"""WSGI server exposing health-check endpoints."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable
+from wsgiref.simple_server import make_server
+
+from core.health import HealthChecker
+
+
+def create_app(checker: HealthChecker | None = None) -> Callable:
+    """Return a WSGI app providing ``/healthz``."""
+
+    checker = checker or HealthChecker()
+
+    def app(environ: dict, start_response: Callable) -> Iterable[bytes]:
+        path = environ.get("PATH_INFO", "")
+        if environ.get("REQUEST_METHOD") == "GET" and path == "/healthz":
+            status = "200 OK"
+            body = checker.check()
+            start_response(status, [("Content-Type", "application/json")])
+            return [f"{{\"status\": \"{body['status']}\"}}".encode()]
+
+        start_response("404 Not Found", [("Content-Type", "text/plain")])
+        return [b"Not Found"]
+
+    return app
+
+
+def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Launch the WSGI server."""
+
+    with make_server(host, port, create_app()) as httpd:
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .eidos_core import EidosCore
 from .meta_reflection import MetaReflection
+from .health import HealthChecker
 
-__all__ = ["EidosCore", "MetaReflection"]
+__all__ = ["EidosCore", "MetaReflection", "HealthChecker"]

--- a/core/health.py
+++ b/core/health.py
@@ -1,0 +1,11 @@
+"""Health-check utilities for container monitoring."""
+
+from __future__ import annotations
+
+
+class HealthChecker:
+    """Provide a basic status report for the system."""
+
+    def check(self) -> dict[str, str]:
+        """Return a simple health dictionary."""
+        return {"status": "ok"}

--- a/knowledge/eidos_logbook.md
+++ b/knowledge/eidos_logbook.md
@@ -80,3 +80,11 @@
 - Documented persistence checks in test suite
 
 **Next Target:** Improve reflection detail generation and automate glossary updates
+
+## Cycle 10: Health Checks
+- Introduced a simple WSGI API with a `/healthz` endpoint.
+- Added `HealthChecker` utility class for status reporting.
+- Updated documentation templates with a WSGI API example.
+- Documented API usage in the README and generated new tests.
+
+**Next Target:** Expand API capabilities and automate health monitoring.

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,18 +1,18 @@
 # Glossary Reference
 
-This generated list standardizes terminology used across all documentation.
-Refer back to `templates.md` for code usage examples and to
-`recursive_patterns.md` for context on how these terms interact recursively.
-
 ## Classes
 - EidosCore
 - ExperimentAgent
+- HealthChecker
 - MetaReflection
 - UtilityAgent
 
 ## Functions
+- build_parser
+- create_app
 - load_memory
 - main
+- run_server
 - save_memory
 
 ## Constants

--- a/knowledge/templates.md
+++ b/knowledge/templates.md
@@ -43,3 +43,30 @@ def test_feature() -> None:
     result = function_under_test()
     assert result == expected
 ```
+
+## WSGI API Template
+```python
+from wsgiref.simple_server import make_server
+
+from core.health import HealthChecker
+
+
+def create_app(checker: HealthChecker | None = None):
+    """Return a WSGI application with a health endpoint."""
+
+    checker = checker or HealthChecker()
+
+    def app(environ, start_response):
+        if environ.get("PATH_INFO") == "/healthz":
+            start_response("200 OK", [("Content-Type", "application/json")])
+            return [b'{"status": "ok"}']
+        start_response("404 Not Found", [])
+        return [b""]
+
+    return app
+
+
+def run_server() -> None:
+    with make_server("0.0.0.0", 8000, create_app()) as server:
+        server.serve_forever()
+```

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,0 +1,35 @@
+from api import create_app
+from core.health import HealthChecker
+
+
+def run_app(path: str) -> tuple[str, bytes]:
+    """Utility to run the WSGI app for ``path`` and capture response."""
+
+    app = create_app(HealthChecker())
+    captured: dict[str, str] = {}
+
+    def start_response(status: str, headers: list[tuple[str, str]]) -> None:
+        captured["status"] = status
+        captured["headers"] = dict(headers)
+
+    environ = {
+        "REQUEST_METHOD": "GET",
+        "PATH_INFO": path,
+        "SERVER_NAME": "test",
+        "SERVER_PORT": "80",
+        "wsgi.input": b"",
+    }
+
+    result = b"".join(app(environ, start_response))
+    return captured.get("status", ""), result
+
+
+def test_healthz_returns_ok() -> None:
+    status, body = run_app("/healthz")
+    assert status.startswith("200")
+    assert body == b'{"status": "ok"}'
+
+
+def test_unknown_path_returns_404() -> None:
+    status, _ = run_app("/missing")
+    assert status.startswith("404")

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -6,7 +6,7 @@ import ast
 from pathlib import Path
 
 OUTPUT_PATH = Path("knowledge/glossary_reference.md")
-SOURCE_DIRS = ["core", "agents", "labs"]
+SOURCE_DIRS = ["core", "agents", "labs", "api"]
 
 
 def extract_symbols(path: Path) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- add `HealthChecker` utility
- add minimal WSGI server with `/healthz`
- document API directory and usage
- update glossary generator to scan the new API
- include API template and logbook entry
- test new health endpoint

## Testing
- `black --check core api tools tests`
- `flake8 core api tools tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2c32192083238afea7f3ef682ab6