### PR TITLE
Improve API utilities and core metrics

### DIFF
--- a/agents/experiment_agent.py
+++ b/agents/experiment_agent.py
@@ -13,11 +13,12 @@ class ExperimentAgent(Agent):
     def run(self, hypothesis: str) -> str:
         """Backward-compatible wrapper for :meth:`act`."""
         import warnings
+
         warnings.warn(
             "The `run` method is deprecated and will be removed in a future release. "
             "Please use the `act` method directly.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return self.act(hypothesis)
 

--- a/agents/utility_agent.py
+++ b/agents/utility_agent.py
@@ -1,5 +1,7 @@
 """General-purpose utilities for Eidos."""
 
+import warnings
+
 from .base_agent import Agent
 
 
@@ -16,7 +18,7 @@ class UtilityAgent(Agent):
             "perform_task is deprecated and will be removed in a future release. "
             "Please use the act method instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return self.act(task)
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,4 @@
-"""API package exposing EidosCore through FastAPI."""
-"""Minimal WSGI API exposing Eidos services."""
+"""Expose Eidos functionality via FastAPI and WSGI helpers."""
 
 from .server import create_app, run_server
 

--- a/api/server.py
+++ b/api/server.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+from wsgiref.simple_server import make_server
+from typing import Callable
 
 from fastapi import FastAPI
 
 from core.eidos_core import EidosCore
+from core.health import HealthChecker
 
 HOST = os.getenv("HOST", "0.0.0.0")
 PORT = int(os.getenv("PORT", "8000"))
@@ -14,6 +17,28 @@ ENABLE_UI = os.getenv("ENABLE_UI", "false").lower() == "true"
 
 app = FastAPI(title="Eidos API", docs_url="/docs" if ENABLE_UI else None)
 core = EidosCore()
+
+
+def create_app(checker: HealthChecker | None = None) -> Callable:
+    """Return a WSGI app exposing a ``/healthz`` endpoint."""
+
+    checker = checker or HealthChecker()
+
+    def wsgi_app(environ: dict, start_response: Callable) -> list[bytes]:
+        if environ.get("PATH_INFO") == "/healthz":
+            start_response("200 OK", [("Content-Type", "application/json")])
+            return [b'{"status": "ok"}']
+        start_response("404 Not Found", [])
+        return [b""]
+
+    return wsgi_app
+
+
+def run_server() -> None:
+    """Launch the WSGI server using :func:`create_app`."""
+
+    with make_server(HOST, PORT, create_app()) as server:
+        server.serve_forever()
 
 
 @app.get("/memories")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,4 +7,3 @@ from .event_bus import EventBus
 from .health import HealthChecker
 
 __all__ = ["EidosCore", "MetaReflection", "HealthChecker", "EventBus", "LLMAdapter"]
-

--- a/core/eidos_core.py
+++ b/core/eidos_core.py
@@ -68,3 +68,7 @@ class EidosCore:
         """
         self.remember(experience)
         self.recurse()
+
+    def memory_count(self) -> int:
+        """Return the current number of stored memories."""
+        return len(self.memory)

--- a/knowledge/glossary_reference.md
+++ b/knowledge/glossary_reference.md
@@ -1,15 +1,12 @@
 # Glossary Reference
 
 ## Classes
--EidosCore
--Experience
--ExperimentAgent
--MetaReflection
--UtilityAgent
 - Agent
 - EidosCore
 - EventBus
+- Experience
 - ExperimentAgent
+- HealthChecker
 - LLMAdapter
 - MemoryItem
 - MetaReflection
@@ -18,19 +15,16 @@
 ## Functions
 - add_memory
 - build_parser
+- create_app
 - get_memories
 - load_memory
 - main
-- process
-- run_recurse
-- build_parser
-- load_memory
-- main
 - memories
+- process
 - remember
-- save_memory
-- create_app
+- run_recurse
 - run_server
+- save_memory
 
 ## Constants
 - ENABLE_UI

--- a/labs/__init__.py
+++ b/labs/__init__.py
@@ -1,0 +1,6 @@
+"""Experimental modules and utilities for Eidos-Brain."""
+
+from .api_app import create_app
+from .tutorial_app import main as tutorial_main
+
+__all__ = ["create_app", "tutorial_main"]


### PR DESCRIPTION
## Summary
- support labs as a package
- add `memory_count` to `EidosCore`
- provide a WSGI `create_app` and `run_server` in `api.server`
- standardize API package docstring
- document new symbols in glossary
- import `warnings` in `UtilityAgent`

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684d41a3b5a883238619d973c1d0951f